### PR TITLE
safer dev default pull policy

### DIFF
--- a/k8s/outputs/operator.cue
+++ b/k8s/outputs/operator.cue
@@ -188,7 +188,8 @@ operator_crd: [
   },
 ]
 
-OperatorPullPolicy: string | *"IfNotPresent" @tag(operator_pull_policy)
+// CI requires "IfNotPresent" (and sets it with this tag) but Always is safer for development
+OperatorPullPolicy: string | *"Always" @tag(operator_pull_policy)
 
 operator_sts: [
   appsv1.#StatefulSet & {


### PR DESCRIPTION
CI requires IfNotPresent for the operator, because we want to side-load an image. IfNotPresent avoids fetching a different one from the server. However, Always is a safer default for development work, because it's harder to accidentally run an image different from the one you just built locally.

This PR makes "Always" the default, and https://github.com/greymatter-io/operator/pull/122 tells CI to explicitly specify IfNotPresent for CI purposes.