### PR TITLE
Add Prometheus k8s and mesh configs

### DIFF
--- a/gm/intermediates.cue
+++ b/gm/intermediates.cue
@@ -81,7 +81,7 @@ import (
 		http_filters: {
 			gm_metrics: {
 				metrics_host:                               "0.0.0.0"
-				metrics_port:                               8081
+				metrics_port:                               defaults.ports.metrics
 				metrics_dashboard_uri_path:                 "/metrics"
 				metrics_prometheus_uri_path:                "/prometheus"
 				metrics_ring_buffer_size:                   4096

--- a/gm/outputs/EXTRACTME.cue
+++ b/gm/outputs/EXTRACTME.cue
@@ -11,10 +11,10 @@ mesh_configs: redis_config +
              controlensemble_config +
              dashboard_config +
              catalog_entries +
-             [for x in prometheus_config if config.enable_metrics {x} ]
+             [for x in prometheus_config if config.enable_historical_metrics {x} ]
 redis_listener: redis_listener_object // special because we need to re-apply it when Spire is enabled for every new sidecar
 
-prometheus_mesh_configs: [for x in prometheus_config if config.enable_metrics {x} ] + catalog_entries
+prometheus_mesh_configs: [for x in prometheus_config if config.enable_historical_metrics {x} ] + catalog_entries
 
 // for CLI convenience,
 // e.g. `cue eval -c ./gm/outputs --out text -e mesh_configs_yaml`

--- a/gm/outputs/EXTRACTME.cue
+++ b/gm/outputs/EXTRACTME.cue
@@ -6,11 +6,12 @@ package greymatter
 import "encoding/yaml"
 
 mesh_configs: redis_config +
-             edge_config +
-             catalog_config +
-             controlensemble_config +
-             dashboard_config +
-             catalog_entries
+	edge_config +
+	catalog_config +
+	controlensemble_config +
+	dashboard_config +
+	catalog_entries +
+		[ for x in prometheus_config if config.enable_metrics {x}]
 redis_listener: redis_listener_object // special because we need to re-apply it when Spire is enabled for every new sidecar
 
 // for CLI convenience,

--- a/gm/outputs/EXTRACTME.cue
+++ b/gm/outputs/EXTRACTME.cue
@@ -6,16 +6,20 @@ package greymatter
 import "encoding/yaml"
 
 mesh_configs: redis_config +
-	edge_config +
-	catalog_config +
-	controlensemble_config +
-	dashboard_config +
-	catalog_entries +
-		[ for x in prometheus_config if config.enable_metrics {x}]
+             edge_config +
+             catalog_config +
+             controlensemble_config +
+             dashboard_config +
+             catalog_entries +
+             [for x in prometheus_config if config.enable_metrics {x} ]
 redis_listener: redis_listener_object // special because we need to re-apply it when Spire is enabled for every new sidecar
+
+prometheus_mesh_configs: [for x in prometheus_config if config.enable_metrics {x} ] + catalog_entries
 
 // for CLI convenience,
 // e.g. `cue eval -c ./gm/outputs --out text -e mesh_configs_yaml`
 mesh_configs_yaml: yaml.MarshalStream(mesh_configs)
+
+prometheus_mesh_configs_yaml: yaml.MarshalStream(prometheus_mesh_configs)
 
 sidecar_config: #sidecar_config // pass a Name and Port

--- a/gm/outputs/catalogentries.cue
+++ b/gm/outputs/catalogentries.cue
@@ -16,9 +16,9 @@ import (
 	api_endpoint?:             string
 	api_spec_endpoint?:        string
 	description?:              string
-	enable_instance_metrics:   bool
-	enable_historical_metrics: bool
-	
+	enable_instance_metrics:   bool | *config.enable_metrics
+	enable_historical_metrics: bool | *config.enable_metrics
+
 	// missing fields from official cue repo
 	business_impact: string // FYI the Go currently uses this field to determine whether this is a catalog service entry
 	version?: string
@@ -35,8 +35,6 @@ catalog_entries: [
 		description:     "Handles north/south traffic flowing through the mesh."
 		api_endpoint:    "/"
 		business_impact: "critical"
-		enable_instance_metrics: true
-		enable_historical_metrics: false
 	},
 	#CatalogService & {
 		name:              "Grey Matter Control"
@@ -47,8 +45,6 @@ catalog_entries: [
 		api_endpoint:      "/services/control-api/"
 		business_impact:   "critical"
 		api_spec_endpoint: "/services/control-api/"
-		enable_instance_metrics: true
-		enable_historical_metrics: false
 	},
 	#CatalogService & {
 		name:              "Grey Matter Catalog"
@@ -59,8 +55,6 @@ catalog_entries: [
 		api_endpoint:      "/services/catalog/"
 		api_spec_endpoint: "/services/catalog/"
 		business_impact:   "high"
-		enable_instance_metrics: true
-		enable_historical_metrics: false
 	},
 	#CatalogService & {
 		name:            "Grey Matter Dashboard"
@@ -69,7 +63,16 @@ catalog_entries: [
 		version:         strings.Split(mesh.spec.images.dashboard, ":")[1]
 		description:     "A user dashboard that paints a high-level picture of the mesh."
 		business_impact: "high"
-		enable_instance_metrics: true
-		enable_historical_metrics: false
+	},
+	if config.enable_metrics {
+		#CatalogService & {
+			name:            "Grey Matter Prometheus"
+			mesh_id: mesh.metadata.name
+			service_id: "prometheus"
+			version:         strings.Split(mesh.spec.images.prometheus, ":")[1]
+			description:     "Prometheus Metrics."
+			business_impact: "low"
+
+		}
 	}
 ]

--- a/gm/outputs/catalogentries.cue
+++ b/gm/outputs/catalogentries.cue
@@ -3,7 +3,7 @@
 package greymatter
 
 import (
-//  "greymatter.io/operator/greymatter-cue/greymatter"
+	//  "greymatter.io/operator/greymatter-cue/greymatter"
 	"strings"
 )
 
@@ -16,12 +16,12 @@ import (
 	api_endpoint?:             string
 	api_spec_endpoint?:        string
 	description?:              string
-	enable_instance_metrics:   bool | *config.enable_historical_metrics
+	enable_instance_metrics:   bool | *true
 	enable_historical_metrics: bool | *config.enable_historical_metrics
 
 	// missing fields from official cue repo
 	business_impact: string // FYI the Go currently uses this field to determine whether this is a catalog service entry
-	version?: string
+	version?:        string
 }
 
 // TODO these should get their own defaults treatment in gm/intermediates.cue
@@ -29,8 +29,8 @@ import (
 catalog_entries: [
 	#CatalogService & {
 		name:            "Grey Matter Edge"
-		mesh_id: mesh.metadata.name
-		service_id: "edge"
+		mesh_id:         mesh.metadata.name
+		service_id:      "edge"
 		version:         strings.Split(mesh.spec.images.proxy, ":")[1]
 		description:     "Handles north/south traffic flowing through the mesh."
 		api_endpoint:    "/"
@@ -38,9 +38,9 @@ catalog_entries: [
 	},
 	#CatalogService & {
 		name:              "Grey Matter Control"
-		mesh_id: mesh.metadata.name
-		service_id: "controlensemble"
-		version:         strings.Split(mesh.spec.images.control_api, ":")[1]
+		mesh_id:           mesh.metadata.name
+		service_id:        "controlensemble"
+		version:           strings.Split(mesh.spec.images.control_api, ":")[1]
 		description:       "Manages the configuration of the Grey Matter data plane."
 		api_endpoint:      "/services/control-api/"
 		business_impact:   "critical"
@@ -48,9 +48,9 @@ catalog_entries: [
 	},
 	#CatalogService & {
 		name:              "Grey Matter Catalog"
-		mesh_id: mesh.metadata.name
-		service_id: "catalog"
-		version:         strings.Split(mesh.spec.images.catalog, ":")[1]
+		mesh_id:           mesh.metadata.name
+		service_id:        "catalog"
+		version:           strings.Split(mesh.spec.images.catalog, ":")[1]
 		description:       "Interfaces with the control plane to expose the current state of the mesh."
 		api_endpoint:      "/services/catalog/"
 		api_spec_endpoint: "/services/catalog/"
@@ -58,8 +58,8 @@ catalog_entries: [
 	},
 	#CatalogService & {
 		name:            "Grey Matter Dashboard"
-		mesh_id: mesh.metadata.name
-		service_id: "dashboard"
+		mesh_id:         mesh.metadata.name
+		service_id:      "dashboard"
 		version:         strings.Split(mesh.spec.images.dashboard, ":")[1]
 		description:     "A user dashboard that paints a high-level picture of the mesh."
 		business_impact: "high"
@@ -67,13 +67,12 @@ catalog_entries: [
 	if config.enable_historical_metrics {
 		#CatalogService & {
 			name:            "Grey Matter Prometheus"
-			mesh_id: mesh.metadata.name
-			service_id: "prometheus"
+			mesh_id:         mesh.metadata.name
+			service_id:      "prometheus"
 			version:         strings.Split(mesh.spec.images.prometheus, ":")[1]
-			description:     "Prometheus TSDB for collecting and querying historical metrics"
+			description:     "Prometheus TSDB for collecting and querying historical metrics."
 			business_impact: "high"
-			api_endpoint: "/services/prometheus/api/v1/"
-
+			api_endpoint:    "/services/prometheus/api/v1/"
 		}
-	}
+	},
 ]

--- a/gm/outputs/catalogentries.cue
+++ b/gm/outputs/catalogentries.cue
@@ -70,8 +70,9 @@ catalog_entries: [
 			mesh_id: mesh.metadata.name
 			service_id: "prometheus"
 			version:         strings.Split(mesh.spec.images.prometheus, ":")[1]
-			description:     "Prometheus Metrics."
-			business_impact: "low"
+			description:     "Prometheus TSDB for collecting and querying historical metrics"
+			business_impact: "high"
+			api_endpoint: "/services/prometheus/api/v1/"
 
 		}
 	}

--- a/gm/outputs/catalogentries.cue
+++ b/gm/outputs/catalogentries.cue
@@ -16,8 +16,8 @@ import (
 	api_endpoint?:             string
 	api_spec_endpoint?:        string
 	description?:              string
-	enable_instance_metrics:   bool | *config.enable_metrics
-	enable_historical_metrics: bool | *config.enable_metrics
+	enable_instance_metrics:   bool | *config.enable_historical_metrics
+	enable_historical_metrics: bool | *config.enable_historical_metrics
 
 	// missing fields from official cue repo
 	business_impact: string // FYI the Go currently uses this field to determine whether this is a catalog service entry
@@ -39,7 +39,7 @@ catalog_entries: [
 	#CatalogService & {
 		name:              "Grey Matter Control"
 		mesh_id: mesh.metadata.name
-	  service_id: "controlensemble"
+		service_id: "controlensemble"
 		version:         strings.Split(mesh.spec.images.control_api, ":")[1]
 		description:       "Manages the configuration of the Grey Matter data plane."
 		api_endpoint:      "/services/control-api/"
@@ -64,7 +64,7 @@ catalog_entries: [
 		description:     "A user dashboard that paints a high-level picture of the mesh."
 		business_impact: "high"
 	},
-	if config.enable_metrics {
+	if config.enable_historical_metrics {
 		#CatalogService & {
 			name:            "Grey Matter Prometheus"
 			mesh_id: mesh.metadata.name

--- a/gm/outputs/prometheus.cue
+++ b/gm/outputs/prometheus.cue
@@ -1,0 +1,64 @@
+// Grey Matter configuration for prometheus's sidecar
+
+package greymatter
+
+let Name= "prometheus"
+let LocalName = Name + "_local"
+let EgressToRedisName = "\(Name)_egress_to_redis"
+
+prometheus_config: [
+  // sidecar->prometheus
+  #domain & { domain_key: LocalName },
+  #listener & {
+    listener_key: LocalName
+    _spire_self: Name
+    _gm_observables_topic: Name
+    _is_ingress: true
+  },
+  #cluster & { cluster_key: LocalName, _upstream_port: 9090 },
+  #route & { route_key: LocalName },
+
+  // egress->redis
+  #domain & { domain_key: EgressToRedisName, port: defaults.ports.redis_ingress },
+  #cluster & {
+    cluster_key: EgressToRedisName
+    name: defaults.redis_cluster_name
+    _spire_self: Name
+    _spire_other: defaults.redis_cluster_name
+  },
+  #route & { route_key: EgressToRedisName }, // unused route must exist for the cluster to be registered with sidecar
+  #listener & {
+    listener_key: EgressToRedisName
+    ip: "127.0.0.1" // egress listeners are local-only
+    port: defaults.ports.redis_ingress
+    _tcp_upstream: defaults.redis_cluster_name // NB this points at a cluster name, not key
+  },
+
+  // shared proxy object
+  #proxy & {
+    proxy_key: Name,
+    domain_keys: [LocalName, EgressToRedisName]
+    listener_keys: [LocalName, EgressToRedisName]
+  },
+
+
+  // edge->sidecar
+  #cluster & {
+    cluster_key: Name
+    _spire_other: Name
+  },
+  #route & { domain_key: "edge",
+  route_key: Name
+  route_match:{
+    path: "/services/" + Name + "/"
+  }
+  redirects: [
+    {
+        from: "^/services/" + Name + "$"
+        to: route_match.path
+        redirect_type: "permanent"
+    }
+  ]
+  prefix_rewrite: "/"
+  }
+]

--- a/gm/outputs/prometheus.cue
+++ b/gm/outputs/prometheus.cue
@@ -1,64 +1,63 @@
-// Grey Matter configuration for prometheus's sidecar
+// Grey Matter configuration for Prometheus's sidecar
 
 package greymatter
 
-let Name= "prometheus"
-let LocalName = Name + "_local"
+let Name = "prometheus"
+let LocalName = "\(Name)_local"
 let EgressToRedisName = "\(Name)_egress_to_redis"
 
 prometheus_config: [
-  // sidecar->prometheus
-  #domain & { domain_key: LocalName },
-  #listener & {
-    listener_key: LocalName
-    _spire_self: Name
-    _gm_observables_topic: Name
-    _is_ingress: true
-  },
-  #cluster & { cluster_key: LocalName, _upstream_port: 9090 },
-  #route & { route_key: LocalName },
+	// sidecar->prometheus
+	#domain & {domain_key: LocalName},
+	#listener & {
+		listener_key:          LocalName
+		_spire_self:           Name
+		_gm_observables_topic: Name
+		_is_ingress:           true
+	},
+	#cluster & {cluster_key: LocalName, _upstream_port: 9090},
+	#route & {route_key:     LocalName},
 
-  // egress->redis
-  #domain & { domain_key: EgressToRedisName, port: defaults.ports.redis_ingress },
-  #cluster & {
-    cluster_key: EgressToRedisName
-    name: defaults.redis_cluster_name
-    _spire_self: Name
-    _spire_other: defaults.redis_cluster_name
-  },
-  #route & { route_key: EgressToRedisName }, // unused route must exist for the cluster to be registered with sidecar
-  #listener & {
-    listener_key: EgressToRedisName
-    ip: "127.0.0.1" // egress listeners are local-only
-    port: defaults.ports.redis_ingress
-    _tcp_upstream: defaults.redis_cluster_name // NB this points at a cluster name, not key
-  },
+	// egress->redis
+	#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
+	#cluster & {
+		cluster_key:  EgressToRedisName
+		name:         defaults.redis_cluster_name
+		_spire_self:  Name
+		_spire_other: defaults.redis_cluster_name
+	},
+	#route & {route_key: EgressToRedisName}, // unused route must exist for the cluster to be registered with sidecar
+	#listener & {
+		listener_key:  EgressToRedisName
+		ip:            "127.0.0.1" // egress listeners are local-only
+		port:          defaults.ports.redis_ingress
+		_tcp_upstream: defaults.redis_cluster_name // NB this points at a cluster name, not key
+	},
 
-  // shared proxy object
-  #proxy & {
-    proxy_key: Name,
-    domain_keys: [LocalName, EgressToRedisName]
-    listener_keys: [LocalName, EgressToRedisName]
-  },
+	// shared proxy object
+	#proxy & {
+		proxy_key: Name
+		domain_keys: [LocalName, EgressToRedisName]
+		listener_keys: [LocalName, EgressToRedisName]
+	},
 
-
-  // edge->sidecar
-  #cluster & {
-    cluster_key: Name
-    _spire_other: Name
-  },
-  #route & { domain_key: "edge",
-  route_key: Name
-  route_match:{
-    path: "/services/" + Name + "/"
-  }
-  redirects: [
-    {
-        from: "^/services/" + Name + "$"
-        to: route_match.path
-        redirect_type: "permanent"
-    }
-  ]
-  prefix_rewrite: "/"
-  }
+	// edge->sidecar
+	#cluster & {
+		cluster_key:  Name
+		_spire_other: Name
+	},
+	#route & {domain_key: "edge"
+				route_key: Name
+		route_match: {
+			path: "/services/prometheus/"
+		}
+		redirects: [
+			{
+				from:          "^/services/prometheus$"
+				to:            route_match.path
+				redirect_type: "permanent"
+			},
+		]
+		prefix_rewrite: "/"
+	},
 ]

--- a/gm/outputs/sidecar.cue
+++ b/gm/outputs/sidecar.cue
@@ -75,7 +75,6 @@ package greymatter
       api_spec_endpoint: "/services/\(Name)/"
       business_impact:   "low"
       enable_instance_metrics: true
-      enable_historical_metrics: false
     },
   ]
 }

--- a/inputs.cue
+++ b/inputs.cue
@@ -10,9 +10,9 @@ config: {
 	spire:           bool | *false @tag(spire,type=bool)           // enable Spire-based mTLS
 	auto_apply_mesh: bool | *true  @tag(auto_apply_mesh,type=bool) // apply the default mesh specified above after a delay
 	openshift:       bool | *false @tag(openshift,type=bool)
-
-	debug: bool | *false @tag(debug,type=bool) // currently just controls k8s/outputs/operator.cue for debugging
-	test:  bool | *false @tag(test,type=bool)  // currently just turns off GitOps so CI integration tests can manipulate directly
+	enable_metrics:  bool | *true  @tag(enable_metrics,type=bool)
+	debug:           bool | *false @tag(debug,type=bool) // currently just controls k8s/outputs/operator.cue for debugging
+	test:            bool | *false @tag(test,type=bool)  // currently just turns off GitOps so CI integration tests can manipulate directly
 
 	// for a hypothetical future where we want to mount specific certificates for operator webhooks, etc.
 	generate_webhook_certs: bool | *true        @tag(generate_webhook_certs,type=bool)
@@ -37,6 +37,8 @@ mesh: meshv1.#Mesh & {
 			control_api: string | *"quay.io/greymatterio/gm-control-api:1.7.1"
 
 			redis: string | *"redis:latest"
+
+			prometheus: string | *"prom/prometheus:v2.36.2"
 		}
 	}
 }
@@ -53,6 +55,7 @@ defaults: {
 	ports: {
 		default_ingress: 10808
 		redis_ingress:   10910
+		metrics:         8081
 	}
 
 	images: {

--- a/inputs.cue
+++ b/inputs.cue
@@ -7,12 +7,12 @@ import (
 
 config: {
 	// Flags
-	spire:           bool | *false @tag(spire,type=bool)           // enable Spire-based mTLS
-	auto_apply_mesh: bool | *true  @tag(auto_apply_mesh,type=bool) // apply the default mesh specified above after a delay
-	openshift:       bool | *false @tag(openshift,type=bool)
-	enable_metrics:  bool | *true  @tag(enable_metrics,type=bool)
-	debug:           bool | *false @tag(debug,type=bool) // currently just controls k8s/outputs/operator.cue for debugging
-	test:            bool | *false @tag(test,type=bool)  // currently just turns off GitOps so CI integration tests can manipulate directly
+	spire:                     bool | *false @tag(spire,type=bool)           // enable Spire-based mTLS
+	auto_apply_mesh:           bool | *true  @tag(auto_apply_mesh,type=bool) // apply the default mesh specified above after a delay
+	openshift:                 bool | *false @tag(openshift,type=bool)
+	enable_historical_metrics: bool | *true  @tag(enable_historical_metrics,type=bool)
+	debug:                     bool | *false @tag(debug,type=bool) // currently just controls k8s/outputs/operator.cue for debugging
+	test:                      bool | *false @tag(test,type=bool)  // currently just turns off GitOps so CI integration tests can manipulate directly
 
 	// for a hypothetical future where we want to mount specific certificates for operator webhooks, etc.
 	generate_webhook_certs: bool | *true        @tag(generate_webhook_certs,type=bool)

--- a/k8s/intermediates.cue
+++ b/k8s/intermediates.cue
@@ -12,10 +12,16 @@ import (
 
 	name:  "sidecar"
 	image: mesh.spec.images.proxy
-	ports: [...corev1.#ContainerPort] | *[{
+	ports: [...corev1.#ContainerPort] | *[
+	{
 		name:          "proxy"
 		containerPort: defaults.ports.default_ingress
-	}]
+	},
+	{
+		name: "metrics"
+		containerPort: defaults.ports.metrics
+	}
+	]
 	env: [
 		{name: "XDS_CLUSTER", value:          _Name},
 		{name: "ENVOY_ADMIN_LOG_PATH", value: "/dev/stdout"},

--- a/k8s/intermediates.cue
+++ b/k8s/intermediates.cue
@@ -13,14 +13,14 @@ import (
 	name:  "sidecar"
 	image: mesh.spec.images.proxy
 	ports: [...corev1.#ContainerPort] | *[
-	{
-		name:          "proxy"
-		containerPort: defaults.ports.default_ingress
-	},
-	{
-		name: "metrics"
-		containerPort: defaults.ports.metrics
-	}
+		{
+			name:          "proxy"
+			containerPort: defaults.ports.default_ingress
+		},
+		{
+			name:          "metrics"
+			containerPort: defaults.ports.metrics
+		},
 	]
 	env: [
 		{name: "XDS_CLUSTER", value:          _Name},
@@ -30,8 +30,8 @@ import (
 		{name: "XDS_HOST", value:             defaults.xds_host},
 		{name: "XDS_PORT", value:             "50000"},
 		if config.spire {
-			{name: "SPIRE_PATH", value:           "/run/spire/socket/agent.sock"},
-		}
+			{name: "SPIRE_PATH", value: "/run/spire/socket/agent.sock"}
+		},
 	]
 	volumeMounts:    #sidecar_volume_mounts + _volume_mounts
 	imagePullPolicy: defaults.image_pull_policy

--- a/k8s/outputs/EXTRACTME.cue
+++ b/k8s/outputs/EXTRACTME.cue
@@ -27,15 +27,18 @@ k8s_manifests: controlensemble +
 	redis +
 	edge +
 	dashboard +
-	[ for x in prometheus if config.enable_metrics {x}] +
+  [ for x in prometheus if config.enable_metrics {x}] +
 	[ for x in openshift_spire if config.openshift && config.spire {x}]
+
+prometheus_yaml: [ for x in prometheus if config.enable_metrics {x}]
 
 // for CLI convenience,
 // e.g. `cue eval -c ./k8s/outputs --out text -e k8s_manifests_yaml`
 operator_manifests_yaml:         yaml.MarshalStream(operator_manifests)
 all_but_operator_manifests_yaml: yaml.MarshalStream(all_but_operator_manifests)
-spire_manifests_yaml:            yaml.MarshalStream(spire_manifests)
-k8s_manifests_yaml:              yaml.MarshalStream(k8s_manifests)
+spire_manifests_yaml: yaml.MarshalStream(spire_manifests)
+k8s_manifests_yaml: yaml.MarshalStream(k8s_manifests)
+prometheus_yamlx: yaml.MarshalStream(prometheus_yaml)
 
 // TODO this was only necessary because I don't know how to pass _Name into #sidecar_container_block
 // from Go. Then I decided to kill two birds with one stone and also put the sidecar_socket_volume in there.

--- a/k8s/outputs/EXTRACTME.cue
+++ b/k8s/outputs/EXTRACTME.cue
@@ -30,7 +30,7 @@ k8s_manifests: controlensemble +
   [ for x in prometheus if config.enable_historical_metrics {x}] +
 	[ for x in openshift_spire if config.openshift && config.spire {x}]
 
-prometheus_yaml: [ for x in prometheus if config.enable_historical_metrics {x}]
+prometheus_manifests: [ for x in prometheus if config.enable_historical_metrics {x}]
 
 // for CLI convenience,
 // e.g. `cue eval -c ./k8s/outputs --out text -e k8s_manifests_yaml`
@@ -38,7 +38,7 @@ operator_manifests_yaml:         yaml.MarshalStream(operator_manifests)
 all_but_operator_manifests_yaml: yaml.MarshalStream(all_but_operator_manifests)
 spire_manifests_yaml: yaml.MarshalStream(spire_manifests)
 k8s_manifests_yaml: yaml.MarshalStream(k8s_manifests)
-prometheus_yamlx: yaml.MarshalStream(prometheus_yaml)
+prometheus_manifests_yaml: yaml.MarshalStream(prometheus_manifests)
 
 // TODO this was only necessary because I don't know how to pass _Name into #sidecar_container_block
 // from Go. Then I decided to kill two birds with one stone and also put the sidecar_socket_volume in there.

--- a/k8s/outputs/EXTRACTME.cue
+++ b/k8s/outputs/EXTRACTME.cue
@@ -27,10 +27,10 @@ k8s_manifests: controlensemble +
 	redis +
 	edge +
 	dashboard +
-  [ for x in prometheus if config.enable_metrics {x}] +
+  [ for x in prometheus if config.enable_historical_metrics {x}] +
 	[ for x in openshift_spire if config.openshift && config.spire {x}]
 
-prometheus_yaml: [ for x in prometheus if config.enable_metrics {x}]
+prometheus_yaml: [ for x in prometheus if config.enable_historical_metrics {x}]
 
 // for CLI convenience,
 // e.g. `cue eval -c ./k8s/outputs --out text -e k8s_manifests_yaml`

--- a/k8s/outputs/EXTRACTME.cue
+++ b/k8s/outputs/EXTRACTME.cue
@@ -27,6 +27,7 @@ k8s_manifests: controlensemble +
 	redis +
 	edge +
 	dashboard +
+	[ for x in prometheus if config.enable_metrics {x}] +
 	[ for x in openshift_spire if config.openshift && config.spire {x}]
 
 // for CLI convenience,

--- a/k8s/outputs/dashboard.cue
+++ b/k8s/outputs/dashboard.cue
@@ -38,9 +38,9 @@ dashboard: [
 								{name: "BASE_URL", value:                     "/services/\(name)/"},
 								{name: "FABRIC_SERVER", value:                "/services/catalog/"},
 								{name: "CONFIG_SERVER", value:                "/services/control-api/v1.0"},
-								{name: "PROMETHEUS_SERVER", value:            "/services/prometheus/api/v1/"},
+								{name: "PROMETHEUS_SERVER", value:            "/services/prometheus/api/v1/"}, //TODO: this is hardcoded and we will need to abstract this up to inputs.cue to make it more smooth
 								{name: "REQUEST_TIMEOUT", value:              "15000"},
-								{name: "USE_PROMETHEUS", value:               "false"},
+								{name: "USE_PROMETHEUS", value:               "\(config.enable_metrics)"},
 								{name: "DISABLE_PROMETHEUS_ROUTES_UI", value: "true"},
 								{name: "ENABLE_INLINE_DOCS", value:           "true"},
 							]

--- a/k8s/outputs/dashboard.cue
+++ b/k8s/outputs/dashboard.cue
@@ -40,7 +40,7 @@ dashboard: [
 								{name: "CONFIG_SERVER", value:                "/services/control-api/v1.0"},
 								{name: "PROMETHEUS_SERVER", value:            "/services/prometheus/api/v1/"},
 								{name: "REQUEST_TIMEOUT", value:              "15000"},
-								{name: "USE_PROMETHEUS", value:               "\(config.enable_metrics)"},
+								{name: "USE_PROMETHEUS", value:               "\(config.enable_historical_metrics)"},
 								{name: "DISABLE_PROMETHEUS_ROUTES_UI", value: "true"},
 								{name: "ENABLE_INLINE_DOCS", value:           "true"},
 							]

--- a/k8s/outputs/dashboard.cue
+++ b/k8s/outputs/dashboard.cue
@@ -38,7 +38,7 @@ dashboard: [
 								{name: "BASE_URL", value:                     "/services/\(name)/"},
 								{name: "FABRIC_SERVER", value:                "/services/catalog/"},
 								{name: "CONFIG_SERVER", value:                "/services/control-api/v1.0"},
-								{name: "PROMETHEUS_SERVER", value:            "/services/prometheus/api/v1/"}, //TODO: this is hardcoded and we will need to abstract this up to inputs.cue to make it more smooth
+								{name: "PROMETHEUS_SERVER", value:            "/services/prometheus/api/v1/"},
 								{name: "REQUEST_TIMEOUT", value:              "15000"},
 								{name: "USE_PROMETHEUS", value:               "\(config.enable_metrics)"},
 								{name: "DISABLE_PROMETHEUS_ROUTES_UI", value: "true"},

--- a/k8s/outputs/prometheus.cue
+++ b/k8s/outputs/prometheus.cue
@@ -1,0 +1,320 @@
+// Output forms for the 
+
+package greymatter
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+  "strings"
+)
+
+let Name = "prometheus"
+
+prometheus: [
+  appsv1.#StatefulSet & {
+    apiVersion: "apps/v1"
+    kind: "StatefulSet"
+    metadata: {
+      name: Name
+      namespace: mesh.spec.install_namespace
+    }
+    spec: {
+      serviceName: Name
+      selector: {
+        matchLabels: {"greymatter.io/cluster": Name}
+      }
+      template: {
+        metadata: {
+          labels: {"greymatter.io/cluster": Name}
+        }
+        spec: #spire_permission_requests & {
+          securityContext:{
+            runAsUser: 2000
+            runAsGroup: 0
+            fsGroup: 2000
+          }
+          containers: [  
+
+            #sidecar_container_block & { _Name: Name },
+
+            {
+              name: "prometheus"
+              image: mesh.spec.images.prometheus
+              ports: [{
+                name: "http"
+                containerPort: 9090
+              }]
+              command: ["/bin/prometheus"]
+              args:[
+                "--query.timeout=4m",
+                "--query.max-samples=5000000000",
+                "--storage.tsdb.path=/var/lib/prometheus/data/data",
+                "--config.file=/etc/prometheus/prometheus.yaml",
+                "--web.console.libraries=/usr/share/prometheus/console_libraries",
+                "--web.console.templates=/usr/share/prometheus/consoles",
+                "--web.enable-admin-api",
+                "--web.external-url=http://anything/services/prometheus", //TODO: this is hardcoded abstract to inputs.cue to sync between gm and k8s (here and dashboard.cue)
+                "--web.route-prefix=/",
+              ]
+              imagePullPolicy: defaults.image_pull_policy
+              volumeMounts:[
+              {
+                name: Name + "-" +"configuration"
+                mountPath: "/etc/prometheus"
+              },
+              {
+                name: Name + "-" + "data"
+                mountPath: "/var/lib/prometheus/data"
+              },
+              ]
+              resources:{
+                requests:{
+                  memory: "8Gi"
+                  cpu: "1"
+                }
+                limits:{
+                  memory: "12Gi"
+                  cpu: "2"
+                }
+              }
+            }, // prometheus
+
+          ] // containers
+
+          volumes: [
+            {
+              name: "catalog-seed",
+              configMap: {name: "catalog-seed", defaultMode: 420}
+            },
+            {
+              name: Name + "-" +"configuration",
+              configMap: {name: Name}
+            },
+            
+          ] + #sidecar_volumes
+          imagePullSecrets: [{name: defaults.image_pull_secret_name}]
+          serviceAccountName: Name
+        }
+      }
+      volumeClaimTemplates: [
+        {
+          apiVersion: "v1"
+          kind: "PersistentVolumeClaim"
+          metadata: name: Name + "-" + "data"
+          spec:{
+            accessModes: ["ReadWriteOnce"],
+            resources: requests: storage: "40Gi"
+          }
+        }
+      ]
+    }
+  },
+
+  corev1.#ServiceAccount & {
+    apiVersion: "v1"
+    kind: "ServiceAccount"
+    metadata: {
+      name: Name
+      namespace: mesh.spec.install_namespace
+    }
+  },
+
+  rbacv1.#ClusterRole & {
+    apiVersion: "rbac.authorization.k8s.io/v1"
+    kind: "ClusterRole"
+    metadata: name: Name
+    rules: [{
+      apiGroups: [""]
+      resources: ["pods"]
+      verbs: ["get", "list", "watch"]
+    }]
+  },
+
+  rbacv1.#ClusterRoleBinding & {
+    apiVersion: "rbac.authorization.k8s.io/v1"
+    kind: "ClusterRoleBinding"
+    metadata: {
+      name: Name
+      namespace: mesh.spec.install_namespace
+    }
+    subjects: [{
+      kind: "ServiceAccount"
+      name: Name
+      namespace: mesh.spec.install_namespace
+    }]
+    roleRef: {
+      kind: "ClusterRole"
+      name: Name
+      apiGroup: "rbac.authorization.k8s.io"
+    }
+  },
+
+  corev1.#ConfigMap & {
+    apiVersion: "v1"
+    kind: "ConfigMap"
+    metadata: {
+      name: Name
+      namespace: mesh.spec.install_namespace
+    }
+    data: {
+      "prometheus.yaml": """
+      global:
+        scrape_interval:     5s
+        evaluation_interval: 2m
+
+      # References the recording rules YAML file below
+      rule_files:
+        - "/etc/prometheus/recording_rules.yaml"
+
+      scrape_configs:
+        - job_name: 'prometheus'
+          static_configs:
+            - targets: ['localhost:9090']
+        - job_name: 'gm-metrics-kubernetes'
+          metrics_path: /prometheus
+          kubernetes_sd_configs:
+            - role: pod
+              namespaces:
+                names: [\(strings.Join([mesh.spec.install_namespace]+mesh.spec.watch_namespaces, ","))]
+          relabel_configs:
+          # Drop all named ports that are not "metrics"
+          - source_labels: ['__meta_kubernetes_pod_container_port_name']
+            regex: 'metrics'
+            action: 'keep'
+          # Relabel Jobs to the service name and version of the zk path
+          - source_labels: ['__meta_kubernetes_pod_label_greymatter_io_cluster']
+            regex: '(.*)'
+            target_label:  'job'
+            #replacement:   '${1}'
+            replacement:   '${1}'
+        - job_name: 'envoy-metrics-kubernetes'
+          metrics_path: /stats/prometheus
+          kubernetes_sd_configs:
+            - role: pod
+              namespaces:
+                names: [\(strings.Join([mesh.spec.install_namespace]+mesh.spec.watch_namespaces, ","))]
+          relabel_configs:
+          # Drop all named ports that are not "metrics"
+          - source_labels: ['__meta_kubernetes_pod_container_port_name']
+            regex: 'metrics'
+            action: 'keep'
+          # Relabel Jobs to the service name and version of the zk path
+          - source_labels: ['__meta_kubernetes_pod_label_greymatter_io_cluster']
+            regex: '(.*)'
+            target_label:  'job'
+            #replacement:   '${1}'
+            replacement:   '${1}'
+          - source_labels: ['__address__']
+            regex: '(.*):(.*)'
+            target_label:  '__address__'
+            replacement:   '${1}:8001'
+      """
+
+      "recording_rules.yaml": #"""
+      # Dashboard version: 6.0.0-rc.1
+      # time intervals:
+      # ["1h", "4h", "12h"]
+
+      groups:
+        # queries for overall services
+        - name: overviewQueries
+          rules:
+            - record: overviewQueries:avgUpPercent:avg
+              expr: avg by (job) (up)
+            # avgResponseTimeByRoute
+            - record: overviewQueries:avgResponseTimeByRoute_1h:avg
+              expr: avg(rate(http_request_duration_seconds_sum{key!="all"}[1h]) / rate(http_request_duration_seconds_count{key!="all"}[1h]) * 1000 > 0) by (job, key)
+            - record: overviewQueries:avgResponseTimeByRoute_4h:avg
+              expr: avg(rate(http_request_duration_seconds_sum{key!="all"}[4h]) / rate(http_request_duration_seconds_count{key!="all"}[4h]) * 1000 > 0) by (job, key)
+            - record: overviewQueries:avgResponseTimeByRoute_12h:avg
+              expr: avg(rate(http_request_duration_seconds_sum{key!="all"}[12h]) / rate(http_request_duration_seconds_count{key!="all"}[12h]) * 1000 > 0) by (job, key)
+              # numberOfRequestsByRoute
+            - record: overviewQueries:numberOfRequestsByRoute_1h:sum
+              expr: sum(floor(increase(http_request_duration_seconds_count[1h])) >= 1) by (job, key)
+            - record: overviewQueries:numberOfRequestsByRoute_4h:sum
+              expr: sum(floor(increase(http_request_duration_seconds_count[4h])) >= 1) by (job, key)
+            - record: overviewQueries:numberOfRequestsByRoute_12h:sum
+              expr: sum(floor(increase(http_request_duration_seconds_count[12h])) >= 1) by (job, key)
+              # latencyByRoute
+            - record: overviewQueries:latencyByRoute_1h:sum
+              expr: sum without(instance, status)(rate(http_request_duration_seconds_count{key!="all"}[1h])) > 0
+            - record: overviewQueries:latencyByRoute_4h:sum
+              expr: sum without(instance, status)(rate(http_request_duration_seconds_count{key!="all"}[4h])) > 0
+            - record: overviewQueries:latencyByRoute_12h:sum
+              expr: sum without(instance, status)(rate(http_request_duration_seconds_count{key!="all"}[12h])) > 0
+              # error percent
+            - record: overviewQueries:errorPercent_1h:sum
+              expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[1h]) )) by (job) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[1h]) )) by (job) * 100
+            - record: overviewQueries:errorPercent_4h:sum
+              expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[4h]) )) by (job) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[4h]) )) by (job) * 100
+            - record: overviewQueries:errorPercent_12h:sum
+              expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[12h]) )) by (job) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[12h]) )) by (job) * 100
+          # queries for each route
+        - name: queriesByRoute
+          rules:
+            # error percent
+            - record: queriesByRoute:errorPercent_1h:sum
+              expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[1h]) )) by (job, key, method) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[1h]) )) by (job, key, method) * 100
+            - record: queriesByRoute:errorPercent_4h:sum
+              expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[4h]) )) by (job, key, method) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[4h]) )) by (job, key, method) * 100
+            - record: queriesByRoute:errorPercent_12h:sum
+              expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[12h]) )) by (job, key, method) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[12h]) )) by (job, key, method) * 100
+              # p95Latency
+            - record: queriesByRoute:p95Latency_1h:sum
+              expr: round(histogram_quantile(0.95,avg without(instance, status)(rate(http_request_duration_seconds_bucket[1h]))) * 1000, 0.1)
+            - record: queriesByRoute:p95Latency_4h:sum
+              expr: round(histogram_quantile(0.95,avg without(instance, status)(rate(http_request_duration_seconds_bucket[4h]))) * 1000, 0.1)
+            - record: queriesByRoute:p95Latency_12h:sum
+              expr: round(histogram_quantile(0.95,avg without(instance, status)(rate(http_request_duration_seconds_bucket[12h]))) * 1000, 0.1)
+              # p50 latency
+            - record: queriesByRoute:p50Latency_1h:sum
+              expr: round(histogram_quantile(0.50,avg without(instance, status)(rate(http_request_duration_seconds_bucket[1h]))) * 1000, 0.1)
+            - record: queriesByRoute:p50Latency_4h:sum
+              expr: round(histogram_quantile(0.50,avg without(instance, status)(rate(http_request_duration_seconds_bucket[4h]))) * 1000, 0.1)
+            - record: queriesByRoute:p50Latency_12h:sum
+              expr: round(histogram_quantile(0.50,avg without(instance, status)(rate(http_request_duration_seconds_bucket[12h]))) * 1000, 0.1)
+              # request count for route
+            - record: queriesByRoute:requestCount_1h:sum
+              expr: sum(floor(increase(http_request_duration_seconds_count[1h])) >= 1) by (job, key, method)
+            - record: queriesByRoute:requestCount_4h:sum
+              expr: sum(floor(increase(http_request_duration_seconds_count[4h])) >= 1) by (job, key, method)
+            - record: queriesByRoute:requestCount_12h:sum
+              expr: sum(floor(increase(http_request_duration_seconds_count[12h])) >= 1) by (job, key, method)
+          
+          # range queries
+        - name: rangeQueries
+          rules:
+            # pXXLatency range queries
+            - record: rangeQueries:p50Latency:sum
+              expr: round(histogram_quantile(0.50,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
+            - record: rangeQueries:p90Latency:sum
+              expr: round(histogram_quantile(0.90,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
+            - record: rangeQueries:p95Latency:sum
+              expr: round(histogram_quantile(0.95,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
+            - record: rangeQueries:p99Latency:sum
+              expr: round(histogram_quantile(0.99,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
+            - record: rangeQueries:p999Latency:sum
+              expr: round(histogram_quantile(0.999,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
+            - record: rangeQueries:p9999Latency:sum
+              expr: round(histogram_quantile(0.9999,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
+              # error percent by (job, key)
+            - record: rangeQueries:errorPercent:sum
+              expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[1m]) )) by (job, key) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[1m]) )) by (job, key) * 100
+              # respones time per bucket
+            - record: rangeQueries:responseTimeP50:sum
+              expr: round(histogram_quantile(0.50,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
+            - record: rangeQueries:responseTimeP90:sum
+              expr: round(histogram_quantile(0.90,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
+            - record: rangeQueries:responseTimeP95:sum
+              expr: round(histogram_quantile(0.95,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
+            - record: rangeQueries:responseTimeP99:sum
+              expr: round(histogram_quantile(0.99,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
+            - record: rangeQueries:responseTimeP999:sum
+              expr: round(histogram_quantile(0.999,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
+            - record: rangeQueries:responseTimeP9999:sum
+              expr: round(histogram_quantile(0.9999,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
+      """#
+    }
+  },
+]

--- a/k8s/outputs/prometheus.cue
+++ b/k8s/outputs/prometheus.cue
@@ -1,4 +1,4 @@
-// Manifest for Prometheus statefulset, 
+// Manifest for Prometheus statefulset
 
 package greymatter
 
@@ -246,7 +246,7 @@ prometheus: [
 				        expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[4h]) )) by (job) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[4h]) )) by (job) * 100
 				      - record: overviewQueries:errorPercent_12h:sum
 				        expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[12h]) )) by (job) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[12h]) )) by (job) * 100
-				    # queries for each route
+				  # queries for each route
 				  - name: queriesByRoute
 				    rules:
 				      # error percent
@@ -278,7 +278,7 @@ prometheus: [
 				      - record: queriesByRoute:requestCount_12h:sum
 				        expr: sum(floor(increase(http_request_duration_seconds_count[12h])) >= 1) by (job, key, method)
 				    
-				    # range queries
+				  # range queries
 				  - name: rangeQueries
 				    rules:
 				      # pXXLatency range queries

--- a/k8s/outputs/prometheus.cue
+++ b/k8s/outputs/prometheus.cue
@@ -1,4 +1,4 @@
-// Output forms for the 
+// Manifest for Prometheus statefulset, 
 
 package greymatter
 
@@ -6,159 +6,155 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-  "strings"
+	"strings"
 )
 
 let Name = "prometheus"
 
 prometheus: [
-  appsv1.#StatefulSet & {
-    apiVersion: "apps/v1"
-    kind: "StatefulSet"
-    metadata: {
-      name: Name
-      namespace: mesh.spec.install_namespace
-    }
-    spec: {
-      serviceName: Name
-      selector: {
-        matchLabels: {"greymatter.io/cluster": Name}
-      }
-      template: {
-        metadata: {
-          labels: {"greymatter.io/cluster": Name}
-        }
-        spec: #spire_permission_requests & {
-          securityContext:{
-            runAsUser: 2000
-            runAsGroup: 0
-            fsGroup: 2000
-          }
-          containers: [  
+	appsv1.#StatefulSet & {
+		apiVersion: "apps/v1"
+		kind:       "StatefulSet"
+		metadata: {
+			name:      Name
+			namespace: mesh.spec.install_namespace
+		}
+		spec: {
+			serviceName: Name
+			selector: {
+				matchLabels: {"greymatter.io/cluster": Name}
+			}
+			template: {
+				metadata: {
+					labels: {"greymatter.io/cluster": Name}
+				}
+				spec: #spire_permission_requests & {
+					securityContext: {
+						runAsUser:  2000
+						runAsGroup: 0
+						fsGroup:    2000
+					}
+					containers: [
 
-            #sidecar_container_block & { _Name: Name },
+						#sidecar_container_block & {_Name: Name},
 
-            {
-              name: "prometheus"
-              image: mesh.spec.images.prometheus
-              ports: [{
-                name: "http"
-                containerPort: 9090
-              }]
-              command: ["/bin/prometheus"]
-              args:[
-                "--query.timeout=4m",
-                "--query.max-samples=5000000000",
-                "--storage.tsdb.path=/var/lib/prometheus/data/data",
-                "--config.file=/etc/prometheus/prometheus.yaml",
-                "--web.console.libraries=/usr/share/prometheus/console_libraries",
-                "--web.console.templates=/usr/share/prometheus/consoles",
-                "--web.enable-admin-api",
-                "--web.external-url=http://anything/services/prometheus", //TODO: this is hardcoded abstract to inputs.cue to sync between gm and k8s (here and dashboard.cue)
-                "--web.route-prefix=/",
-              ]
-              imagePullPolicy: defaults.image_pull_policy
-              volumeMounts:[
-              {
-                name: Name + "-" +"configuration"
-                mountPath: "/etc/prometheus"
-              },
-              {
-                name: Name + "-" + "data"
-                mountPath: "/var/lib/prometheus/data"
-              },
-              ]
-              resources:{
-                requests:{
-                  memory: "8Gi"
-                  cpu: "1"
-                }
-                limits:{
-                  memory: "12Gi"
-                  cpu: "2"
-                }
-              }
-            }, // prometheus
+						{
+							name:  "prometheus"
+							image: mesh.spec.images.prometheus
+							ports: [{
+								name:          "http"
+								containerPort: 9090
+							}]
+							command: ["/bin/prometheus"]
+							args: [
+								"--query.timeout=4m",
+								"--query.max-samples=5000000000",
+								"--storage.tsdb.path=/var/lib/prometheus/data/data",
+								"--config.file=/etc/prometheus/prometheus.yaml",
+								"--web.console.libraries=/usr/share/prometheus/console_libraries",
+								"--web.console.templates=/usr/share/prometheus/consoles",
+								"--web.enable-admin-api",
+								"--web.external-url=http://anything/services/prometheus",
+								"--web.route-prefix=/",
+							]
+							imagePullPolicy: defaults.image_pull_policy
+							volumeMounts: [
+								{
+									name:      "\(Name)-configuration"
+									mountPath: "/etc/prometheus"
+								},
+								{
+									name:      "\(Name)-data"
+									mountPath: "/var/lib/prometheus/data"
+								},
+							]
+							resources: {
+								requests: {
+									memory: "8Gi"
+									cpu:    "1"
+								}
+								limits: {
+									memory: "12Gi"
+									cpu:    "2"
+								}
+							}
+						},
 
-          ] // containers
+					]
 
-          volumes: [
-            {
-              name: "catalog-seed",
-              configMap: {name: "catalog-seed", defaultMode: 420}
-            },
-            {
-              name: Name + "-" +"configuration",
-              configMap: {name: Name}
-            },
-            
-          ] + #sidecar_volumes
-          imagePullSecrets: [{name: defaults.image_pull_secret_name}]
-          serviceAccountName: Name
-        }
-      }
-      volumeClaimTemplates: [
-        {
-          apiVersion: "v1"
-          kind: "PersistentVolumeClaim"
-          metadata: name: Name + "-" + "data"
-          spec:{
-            accessModes: ["ReadWriteOnce"],
-            resources: requests: storage: "40Gi"
-          }
-        }
-      ]
-    }
-  },
+					volumes: [
+						{
+							name: "\(Name)-configuration"
+							configMap: {name: Name}
+						},
 
-  corev1.#ServiceAccount & {
-    apiVersion: "v1"
-    kind: "ServiceAccount"
-    metadata: {
-      name: Name
-      namespace: mesh.spec.install_namespace
-    }
-  },
+					] + #sidecar_volumes
+					imagePullSecrets: [{name: defaults.image_pull_secret_name}]
+					serviceAccountName: Name
+				}
+			}
+			volumeClaimTemplates: [
+				{
+					apiVersion: "v1"
+					kind:       "PersistentVolumeClaim"
+					metadata: name: "\(Name)-data"
+					spec: {
+						accessModes: ["ReadWriteOnce"]
+						resources: requests: storage: "40Gi"
+					}
+				},
+			]
+		}
+	},
 
-  rbacv1.#ClusterRole & {
-    apiVersion: "rbac.authorization.k8s.io/v1"
-    kind: "ClusterRole"
-    metadata: name: Name
-    rules: [{
-      apiGroups: [""]
-      resources: ["pods"]
-      verbs: ["get", "list", "watch"]
-    }]
-  },
+	corev1.#ServiceAccount & {
+		apiVersion: "v1"
+		kind:       "ServiceAccount"
+		metadata: {
+			name:      Name
+			namespace: mesh.spec.install_namespace
+		}
+	},
 
-  rbacv1.#ClusterRoleBinding & {
-    apiVersion: "rbac.authorization.k8s.io/v1"
-    kind: "ClusterRoleBinding"
-    metadata: {
-      name: Name
-      namespace: mesh.spec.install_namespace
-    }
-    subjects: [{
-      kind: "ServiceAccount"
-      name: Name
-      namespace: mesh.spec.install_namespace
-    }]
-    roleRef: {
-      kind: "ClusterRole"
-      name: Name
-      apiGroup: "rbac.authorization.k8s.io"
-    }
-  },
+	rbacv1.#ClusterRole & {
+		apiVersion: "rbac.authorization.k8s.io/v1"
+		kind:       "ClusterRole"
+		metadata: name: Name
+		rules: [{
+			apiGroups: [""]
+			resources: ["pods"]
+			verbs: ["get", "list", "watch"]
+		}]
+	},
 
-  corev1.#ConfigMap & {
-    apiVersion: "v1"
-    kind: "ConfigMap"
-    metadata: {
-      name: Name
-      namespace: mesh.spec.install_namespace
-    }
-    data: {
-      "prometheus.yaml": """
+	rbacv1.#ClusterRoleBinding & {
+		apiVersion: "rbac.authorization.k8s.io/v1"
+		kind:       "ClusterRoleBinding"
+		metadata: {
+			name:      Name
+			namespace: mesh.spec.install_namespace
+		}
+		subjects: [{
+			kind:      "ServiceAccount"
+			name:      Name
+			namespace: mesh.spec.install_namespace
+		}]
+		roleRef: {
+			kind:     "ClusterRole"
+			name:     Name
+			apiGroup: "rbac.authorization.k8s.io"
+		}
+	},
+
+	corev1.#ConfigMap & {
+		apiVersion: "v1"
+		kind:       "ConfigMap"
+		metadata: {
+			name:      Name
+			namespace: mesh.spec.install_namespace
+		}
+		data: {
+			"prometheus.yaml": """
       global:
         scrape_interval:     5s
         evaluation_interval: 2m
@@ -211,110 +207,110 @@ prometheus: [
             replacement:   '${1}:8001'
       """
 
-      "recording_rules.yaml": #"""
-      # Dashboard version: 6.0.0-rc.1
-      # time intervals:
-      # ["1h", "4h", "12h"]
+			"recording_rules.yaml": #"""
+				# Dashboard version: 6.0.1
+				# time intervals:
+				# ["1h", "4h", "12h"]
 
-      groups:
-        # queries for overall services
-        - name: overviewQueries
-          rules:
-            - record: overviewQueries:avgUpPercent:avg
-              expr: avg by (job) (up)
-            # avgResponseTimeByRoute
-            - record: overviewQueries:avgResponseTimeByRoute_1h:avg
-              expr: avg(rate(http_request_duration_seconds_sum{key!="all"}[1h]) / rate(http_request_duration_seconds_count{key!="all"}[1h]) * 1000 > 0) by (job, key)
-            - record: overviewQueries:avgResponseTimeByRoute_4h:avg
-              expr: avg(rate(http_request_duration_seconds_sum{key!="all"}[4h]) / rate(http_request_duration_seconds_count{key!="all"}[4h]) * 1000 > 0) by (job, key)
-            - record: overviewQueries:avgResponseTimeByRoute_12h:avg
-              expr: avg(rate(http_request_duration_seconds_sum{key!="all"}[12h]) / rate(http_request_duration_seconds_count{key!="all"}[12h]) * 1000 > 0) by (job, key)
-              # numberOfRequestsByRoute
-            - record: overviewQueries:numberOfRequestsByRoute_1h:sum
-              expr: sum(floor(increase(http_request_duration_seconds_count[1h])) >= 1) by (job, key)
-            - record: overviewQueries:numberOfRequestsByRoute_4h:sum
-              expr: sum(floor(increase(http_request_duration_seconds_count[4h])) >= 1) by (job, key)
-            - record: overviewQueries:numberOfRequestsByRoute_12h:sum
-              expr: sum(floor(increase(http_request_duration_seconds_count[12h])) >= 1) by (job, key)
-              # latencyByRoute
-            - record: overviewQueries:latencyByRoute_1h:sum
-              expr: sum without(instance, status)(rate(http_request_duration_seconds_count{key!="all"}[1h])) > 0
-            - record: overviewQueries:latencyByRoute_4h:sum
-              expr: sum without(instance, status)(rate(http_request_duration_seconds_count{key!="all"}[4h])) > 0
-            - record: overviewQueries:latencyByRoute_12h:sum
-              expr: sum without(instance, status)(rate(http_request_duration_seconds_count{key!="all"}[12h])) > 0
-              # error percent
-            - record: overviewQueries:errorPercent_1h:sum
-              expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[1h]) )) by (job) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[1h]) )) by (job) * 100
-            - record: overviewQueries:errorPercent_4h:sum
-              expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[4h]) )) by (job) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[4h]) )) by (job) * 100
-            - record: overviewQueries:errorPercent_12h:sum
-              expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[12h]) )) by (job) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[12h]) )) by (job) * 100
-          # queries for each route
-        - name: queriesByRoute
-          rules:
-            # error percent
-            - record: queriesByRoute:errorPercent_1h:sum
-              expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[1h]) )) by (job, key, method) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[1h]) )) by (job, key, method) * 100
-            - record: queriesByRoute:errorPercent_4h:sum
-              expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[4h]) )) by (job, key, method) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[4h]) )) by (job, key, method) * 100
-            - record: queriesByRoute:errorPercent_12h:sum
-              expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[12h]) )) by (job, key, method) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[12h]) )) by (job, key, method) * 100
-              # p95Latency
-            - record: queriesByRoute:p95Latency_1h:sum
-              expr: round(histogram_quantile(0.95,avg without(instance, status)(rate(http_request_duration_seconds_bucket[1h]))) * 1000, 0.1)
-            - record: queriesByRoute:p95Latency_4h:sum
-              expr: round(histogram_quantile(0.95,avg without(instance, status)(rate(http_request_duration_seconds_bucket[4h]))) * 1000, 0.1)
-            - record: queriesByRoute:p95Latency_12h:sum
-              expr: round(histogram_quantile(0.95,avg without(instance, status)(rate(http_request_duration_seconds_bucket[12h]))) * 1000, 0.1)
-              # p50 latency
-            - record: queriesByRoute:p50Latency_1h:sum
-              expr: round(histogram_quantile(0.50,avg without(instance, status)(rate(http_request_duration_seconds_bucket[1h]))) * 1000, 0.1)
-            - record: queriesByRoute:p50Latency_4h:sum
-              expr: round(histogram_quantile(0.50,avg without(instance, status)(rate(http_request_duration_seconds_bucket[4h]))) * 1000, 0.1)
-            - record: queriesByRoute:p50Latency_12h:sum
-              expr: round(histogram_quantile(0.50,avg without(instance, status)(rate(http_request_duration_seconds_bucket[12h]))) * 1000, 0.1)
-              # request count for route
-            - record: queriesByRoute:requestCount_1h:sum
-              expr: sum(floor(increase(http_request_duration_seconds_count[1h])) >= 1) by (job, key, method)
-            - record: queriesByRoute:requestCount_4h:sum
-              expr: sum(floor(increase(http_request_duration_seconds_count[4h])) >= 1) by (job, key, method)
-            - record: queriesByRoute:requestCount_12h:sum
-              expr: sum(floor(increase(http_request_duration_seconds_count[12h])) >= 1) by (job, key, method)
-          
-          # range queries
-        - name: rangeQueries
-          rules:
-            # pXXLatency range queries
-            - record: rangeQueries:p50Latency:sum
-              expr: round(histogram_quantile(0.50,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
-            - record: rangeQueries:p90Latency:sum
-              expr: round(histogram_quantile(0.90,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
-            - record: rangeQueries:p95Latency:sum
-              expr: round(histogram_quantile(0.95,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
-            - record: rangeQueries:p99Latency:sum
-              expr: round(histogram_quantile(0.99,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
-            - record: rangeQueries:p999Latency:sum
-              expr: round(histogram_quantile(0.999,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
-            - record: rangeQueries:p9999Latency:sum
-              expr: round(histogram_quantile(0.9999,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
-              # error percent by (job, key)
-            - record: rangeQueries:errorPercent:sum
-              expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[1m]) )) by (job, key) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[1m]) )) by (job, key) * 100
-              # respones time per bucket
-            - record: rangeQueries:responseTimeP50:sum
-              expr: round(histogram_quantile(0.50,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
-            - record: rangeQueries:responseTimeP90:sum
-              expr: round(histogram_quantile(0.90,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
-            - record: rangeQueries:responseTimeP95:sum
-              expr: round(histogram_quantile(0.95,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
-            - record: rangeQueries:responseTimeP99:sum
-              expr: round(histogram_quantile(0.99,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
-            - record: rangeQueries:responseTimeP999:sum
-              expr: round(histogram_quantile(0.999,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
-            - record: rangeQueries:responseTimeP9999:sum
-              expr: round(histogram_quantile(0.9999,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
-      """#
-    }
-  },
+				groups:
+				  # queries for overall services
+				  - name: overviewQueries
+				    rules:
+				      - record: overviewQueries:avgUpPercent:avg
+				        expr: avg by (job) (up)
+				      # avgResponseTimeByRoute
+				      - record: overviewQueries:avgResponseTimeByRoute_1h:avg
+				        expr: avg(rate(http_request_duration_seconds_sum{key!="all"}[1h]) / rate(http_request_duration_seconds_count{key!="all"}[1h]) * 1000 > 0) by (job, key)
+				      - record: overviewQueries:avgResponseTimeByRoute_4h:avg
+				        expr: avg(rate(http_request_duration_seconds_sum{key!="all"}[4h]) / rate(http_request_duration_seconds_count{key!="all"}[4h]) * 1000 > 0) by (job, key)
+				      - record: overviewQueries:avgResponseTimeByRoute_12h:avg
+				        expr: avg(rate(http_request_duration_seconds_sum{key!="all"}[12h]) / rate(http_request_duration_seconds_count{key!="all"}[12h]) * 1000 > 0) by (job, key)
+				        # numberOfRequestsByRoute
+				      - record: overviewQueries:numberOfRequestsByRoute_1h:sum
+				        expr: sum(floor(increase(http_request_duration_seconds_count[1h])) >= 1) by (job, key)
+				      - record: overviewQueries:numberOfRequestsByRoute_4h:sum
+				        expr: sum(floor(increase(http_request_duration_seconds_count[4h])) >= 1) by (job, key)
+				      - record: overviewQueries:numberOfRequestsByRoute_12h:sum
+				        expr: sum(floor(increase(http_request_duration_seconds_count[12h])) >= 1) by (job, key)
+				        # latencyByRoute
+				      - record: overviewQueries:latencyByRoute_1h:sum
+				        expr: sum without(instance, status)(rate(http_request_duration_seconds_count{key!="all"}[1h])) > 0
+				      - record: overviewQueries:latencyByRoute_4h:sum
+				        expr: sum without(instance, status)(rate(http_request_duration_seconds_count{key!="all"}[4h])) > 0
+				      - record: overviewQueries:latencyByRoute_12h:sum
+				        expr: sum without(instance, status)(rate(http_request_duration_seconds_count{key!="all"}[12h])) > 0
+				        # error percent
+				      - record: overviewQueries:errorPercent_1h:sum
+				        expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[1h]) )) by (job) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[1h]) )) by (job) * 100
+				      - record: overviewQueries:errorPercent_4h:sum
+				        expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[4h]) )) by (job) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[4h]) )) by (job) * 100
+				      - record: overviewQueries:errorPercent_12h:sum
+				        expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[12h]) )) by (job) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[12h]) )) by (job) * 100
+				    # queries for each route
+				  - name: queriesByRoute
+				    rules:
+				      # error percent
+				      - record: queriesByRoute:errorPercent_1h:sum
+				        expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[1h]) )) by (job, key, method) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[1h]) )) by (job, key, method) * 100
+				      - record: queriesByRoute:errorPercent_4h:sum
+				        expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[4h]) )) by (job, key, method) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[4h]) )) by (job, key, method) * 100
+				      - record: queriesByRoute:errorPercent_12h:sum
+				        expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[12h]) )) by (job, key, method) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[12h]) )) by (job, key, method) * 100
+				        # p95Latency
+				      - record: queriesByRoute:p95Latency_1h:sum
+				        expr: round(histogram_quantile(0.95,avg without(instance, status)(rate(http_request_duration_seconds_bucket[1h]))) * 1000, 0.1)
+				      - record: queriesByRoute:p95Latency_4h:sum
+				        expr: round(histogram_quantile(0.95,avg without(instance, status)(rate(http_request_duration_seconds_bucket[4h]))) * 1000, 0.1)
+				      - record: queriesByRoute:p95Latency_12h:sum
+				        expr: round(histogram_quantile(0.95,avg without(instance, status)(rate(http_request_duration_seconds_bucket[12h]))) * 1000, 0.1)
+				        # p50 latency
+				      - record: queriesByRoute:p50Latency_1h:sum
+				        expr: round(histogram_quantile(0.50,avg without(instance, status)(rate(http_request_duration_seconds_bucket[1h]))) * 1000, 0.1)
+				      - record: queriesByRoute:p50Latency_4h:sum
+				        expr: round(histogram_quantile(0.50,avg without(instance, status)(rate(http_request_duration_seconds_bucket[4h]))) * 1000, 0.1)
+				      - record: queriesByRoute:p50Latency_12h:sum
+				        expr: round(histogram_quantile(0.50,avg without(instance, status)(rate(http_request_duration_seconds_bucket[12h]))) * 1000, 0.1)
+				        # request count for route
+				      - record: queriesByRoute:requestCount_1h:sum
+				        expr: sum(floor(increase(http_request_duration_seconds_count[1h])) >= 1) by (job, key, method)
+				      - record: queriesByRoute:requestCount_4h:sum
+				        expr: sum(floor(increase(http_request_duration_seconds_count[4h])) >= 1) by (job, key, method)
+				      - record: queriesByRoute:requestCount_12h:sum
+				        expr: sum(floor(increase(http_request_duration_seconds_count[12h])) >= 1) by (job, key, method)
+				    
+				    # range queries
+				  - name: rangeQueries
+				    rules:
+				      # pXXLatency range queries
+				      - record: rangeQueries:p50Latency:sum
+				        expr: round(histogram_quantile(0.50,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
+				      - record: rangeQueries:p90Latency:sum
+				        expr: round(histogram_quantile(0.90,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
+				      - record: rangeQueries:p95Latency:sum
+				        expr: round(histogram_quantile(0.95,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
+				      - record: rangeQueries:p99Latency:sum
+				        expr: round(histogram_quantile(0.99,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
+				      - record: rangeQueries:p999Latency:sum
+				        expr: round(histogram_quantile(0.999,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
+				      - record: rangeQueries:p9999Latency:sum
+				        expr: round(histogram_quantile(0.9999,avg without(instance, status)(rate(http_request_duration_seconds_bucket[10m]))) * 1000, 0.1)
+				        # error percent by (job, key)
+				      - record: rangeQueries:errorPercent:sum
+				        expr: sum(floor(increase(http_request_duration_seconds_count{status!~"2..|3..", key!="all"}[1m]) )) by (job, key) / sum(floor(increase(http_request_duration_seconds_count{key!="all"}[1m]) )) by (job, key) * 100
+				        # respones time per bucket
+				      - record: rangeQueries:responseTimeP50:sum
+				        expr: round(histogram_quantile(0.50,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
+				      - record: rangeQueries:responseTimeP90:sum
+				        expr: round(histogram_quantile(0.90,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
+				      - record: rangeQueries:responseTimeP95:sum
+				        expr: round(histogram_quantile(0.95,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
+				      - record: rangeQueries:responseTimeP99:sum
+				        expr: round(histogram_quantile(0.99,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
+				      - record: rangeQueries:responseTimeP999:sum
+				        expr: round(histogram_quantile(0.999,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
+				      - record: rangeQueries:responseTimeP9999:sum
+				        expr: round(histogram_quantile(0.9999,avg without(instance, status, key, method)(rate(http_request_duration_seconds_bucket{key!="all"}[10m]))) * 1000, 0.1)
+				"""#
+		}
+	},
 ]


### PR DESCRIPTION
[sc-10539]

Adds prometheus to k8s.  Creating prometheus, its mesh configs, updating catalog entries and dashboard configs can be toggled by changing `defaults.enable_metrics` in the input.cue.