### PR TITLE
Add load balancer configurations

### DIFF
--- a/gm/intermediates.cue
+++ b/gm/intermediates.cue
@@ -181,10 +181,13 @@ import (
 	_spire_self:              string // can specify current identity - defaults to "edge"
 	_spire_other:             string // can specify an allowable upstream identity - defaults to "edge"
 	_enable_circuit_breakers: bool | *false
+	// We can expand options here for load balancers that superseed the lb_policy field
+	_load_balancer: "round_robin" | "least_request" | "maglev" | "ring_hash" | "random"
 
 	cluster_key: string
 	name:        string | *cluster_key
 	instances:   [...greymatter.#Instance] | *[]
+	
 	if _upstream_port != _|_ {
 		instances: [{host: _upstream_host, port: _upstream_port}]
 	}
@@ -203,6 +206,22 @@ import (
 	if _enable_circuit_breakers {
 		circuit_breakers: #circuit_breaker // can specify circuit breaker levels for normal
 		// and high priority traffic with configured defaults
+	}
+	if _load_balancer != _|_ {
+		lb_policy: _load_balancer
+		if lb_policy == "least_request" {
+			least_request_lb_conf: {
+				choice_count: uint32 | *2
+			}
+		}
+
+		if lb_policy == "ring_hash" || lb_policy == "maglev" {
+			ring_hash_lb_conf: {
+				minimum_ring_size?: uint64 & <8388608 | *1024
+				hash_func?:         uint32 | *0 //corresponds to the xxHash; 1 for MURMUR_HASH_2 
+				maximum_ring_size?: uint64 & <8388608 | *4194304 // 4M
+			}
+		}
 	}
 }
 

--- a/inputs.cue
+++ b/inputs.cue
@@ -25,7 +25,7 @@ mesh: meshv1.#Mesh & {
 	}
 	spec: {
 		install_namespace: string | *"greymatter"
-		watch_namespaces:  [...string] | *["default", "plus"]
+		watch_namespaces:  [...string] | *["default", "plus", "produce-aisle"]
 		release_version:   string | *"1.7" // deprecated
 		zone:              string | *"default-zone"
 		images: {


### PR DESCRIPTION
## Description

## Testing
### CUE evals
Make sure that the CUE evaluates with the correct values. When you use least_request or hash_ring load balancers ensure that their respective configuration options are included in the cluster (they are set to default values).
### Functional Testing
You can do all testing on the kops cluster I created and populated. There are 4 deployed services, each with a different type of load balancing (all the ones we support).
`awsume bs-resources-admin`
`kops export kubeconfig jack.k8s.local --admin`
`k get pods -A` to verify
#### apple - round_robin
In a terminal window, attach to an apple pod's logs:
`kubectl logs -n produce-aisle apple-755654bd79-85nl6 -c sidecar -f`
in a separate window:
`curl -vL a2148c3dcdd7240ca99350a3f49b73d3-557938267.us-east-1.elb.amazonaws.com:10808/services/apple`

Run it a few times, and make sure each pod gets distributed requests.
Requests might not looks distributed according to: https://www.envoyproxy.io/docs/envoy/latest/faq/load_balancing/concurrency_lb apparently concurrency
but actually are.
#### banana - random
attach to a banana pod sidecar logs:
`k logs -n produce-aisle banana-6686658c97-7s45c -f -c sidecar`
in a separate window, make requests: `curl -vL a2148c3dcdd7240ca99350a3f49b73d3-557938267.us-east-1.elb.amazonaws.com:10808/services/banana`

You should see requests in the logs... randomly. 
#### lettuce - least_request
This time, we want to exec into the pod to check envoy's metrics.
`k exec -it -n produce-aisle lettuce-577c777fc8-7vths -c sidecar -- bash`
Note the number of requests: `curl -s localhost:8001/stats | grep 'cluster.lettuce-ingress-to-lettuce.external.upstream_rq_200'`
Now run a series of curl requests against the lettuce cluster. Ideally, the rate at which requests are proxied is faster than the rate at which requests are completed. This will trigger the least request lb policy:
`for i in {1..10}; do curl -vL a2148c3dcdd7240ca99350a3f49b73d3-557938267.us-east-1.elb.amazonaws.com:10808/services/lettuce &; done;`
When those finish, just verify that the requests were out of order. the total completed requests again:
`curl -s localhost:8001/stats | grep 'cluster.lettuce-ingress-to-lettuce.external.upstream_rq_200`
The number should be higher than the original but lower than the original + 10. 
#### tomato - ring_hash
I can't figure out what envoy actually hashes in the request to come up with a matching server. But if you tail the logs of each tomato sidecar, you can see that requests will get load balanced between all three. 
Just send a regular curl req:
`curl -vL a2148c3dcdd7240ca99350a3f49b73d3-557938267.us-east-1.elb.amazonaws.com:10808/services/tomato`
For maglev:
go into the tomato service cue, and replace ring_hash with maglev: `EDITOR=your_favorite_editor greymatter edit cluster -k tomato`. 
Wait a few moments for configs to propagate. 
Perform the same test for ring_hash