### PR TITLE
add ext_authz toggle to edge.cue

### DIFF
--- a/gm/outputs/edge.cue
+++ b/gm/outputs/edge.cue
@@ -19,6 +19,7 @@ edge_config: [
 		_enable_oidc_authentication: false
 		_enable_rbac:                false
 		_enable_fault_injection:     false
+		_enable_ext_authz:           false
 		_oidc_endpoint:              defaults.edge.oidc.endpoint
 		_oidc_service_url:           "https://\(defaults.edge.oidc.domain):\(defaults.ports.edge_ingress)"
 		_oidc_provider:              "\(defaults.edge.oidc.endpoint)/auth/realms/\(defaults.edge.oidc.realm)"


### PR DESCRIPTION
I like having the toggle right in the edge.cue file because it's simpler to change the boolean than copy/pasting the k/v pair. I also updated the OPA section of the playbook to reflect this.