### PR TITLE
Enable greymatter to use an external prometheus; enable tls connectio…

### DIFF
--- a/gm/outputs/catalogentries.cue
+++ b/gm/outputs/catalogentries.cue
@@ -24,6 +24,11 @@ import (
 	version?:        string
 }
 
+prometheusName: [
+	if len(defaults.prometheus.external_host) > 0 { "Grey Matter Prometheus Proxy" },
+	"Grey Matter Prometheus",
+][0]
+
 // TODO these should get their own defaults treatment in gm/intermediates.cue
 
 catalog_entries: [
@@ -66,13 +71,13 @@ catalog_entries: [
 	},
 	if config.enable_historical_metrics {
 		#CatalogService & {
-			name:            "Grey Matter Prometheus"
+			name:            prometheusName
 			mesh_id:         mesh.metadata.name
 			service_id:      "prometheus"
 			version:         strings.Split(mesh.spec.images.prometheus, ":")[1]
 			description:     "Prometheus TSDB for collecting and querying historical metrics."
 			business_impact: "high"
-			api_endpoint:    "/services/prometheus/api/v1/"
+			api_endpoint:    "/services/prometheus/graph"
 		}
 	},
 ]

--- a/gm/outputs/edge.cue
+++ b/gm/outputs/edge.cue
@@ -52,7 +52,7 @@ edge_config: [
 		proxy_key: defaults.edge.key
 		domain_keys: [defaults.edge.key, EgressToRedisName]
 		listener_keys: [defaults.edge.key, EgressToRedisName]
-	}
+	},
 
 	// egress->Keycloak for OIDC/JWT Authentication (only necessary with remote JWKS provider)
 	// NB: You need to add the EdgeToKeycloakName key to the domain_keys and listener_keys 
@@ -70,7 +70,7 @@ edge_config: [
 	// #route & {route_key:   EdgeToKeycloakName},
 	// #domain & {domain_key: EdgeToKeycloakName, port: defaults.edge.oidc.endpoint_port},
 	// #listener & {
-	//  listener_key: EdgeToKeycloakName
-	//  port:         defaults.edge.oidc.endpoint_port
+	// 	listener_key: EdgeToKeycloakName
+	// 	port:         defaults.edge.oidc.endpoint_port
 	// },
 ]

--- a/gm/outputs/prometheus.cue
+++ b/gm/outputs/prometheus.cue
@@ -15,7 +15,29 @@ prometheus_config: [
 		_gm_observables_topic: Name
 		_is_ingress:           true
 	},
-	#cluster & {cluster_key: LocalName, _upstream_port: 9090},
+	#cluster & {
+		cluster_key: LocalName,
+		if len(defaults.prometheus.external_host) > 0 {
+			_upstream_host: defaults.prometheus.external_host
+		}
+		_upstream_port: [
+			if defaults.prometheus.port != _|_ { defaults.prometheus.port },
+			9090, //9090 is the default for when prometheus is deployed with greymatter
+		][0]
+		
+		if defaults.prometheus.tls.enabled {
+			require_tls: true
+			ssl_config: {
+				cert_key_pairs: [
+					{
+						certificate_path: "/etc/proxy/tls/prometheus/server.crt"
+						key_path: "/etc/proxy/tls/prometheus/server.key"
+					}
+				]
+			}
+		}
+	},
+
 	#route & {route_key:     LocalName},
 
 	// egress->redis

--- a/inputs.cue
+++ b/inputs.cue
@@ -60,6 +60,18 @@ defaults: {
 		operator: string | *"quay.io/greymatterio/operator:0.9.2" @tag(operator_image)
 	}
 
+	// The external_host field instructs greymatter to install Prometheus or uses an external one.
+	//   If enable_historical_metrics is true and external_host is empty, then greymatter will install Prometheus into the greymatter namespace.
+	//   If enable_historical_metrics is true and external_host has a value, greymatter will not install Prometheus into the greymatter namespace and connect to the external Prometheus via a sidecar (e.g. external_host: prometheus.metrics.svc).
+	prometheus: {
+		external_host: ""
+		port:          9090
+		tls: {
+			enabled:     false
+			cert_secret: "gm-prometheus-certs"
+		}
+	}
+
 	edge: {
 		key:        "edge"
 		enable_tls: false

--- a/k8s/outputs/EXTRACTME.cue
+++ b/k8s/outputs/EXTRACTME.cue
@@ -27,10 +27,13 @@ k8s_manifests: controlensemble +
 	redis +
 	edge +
 	dashboard +
-  [ for x in prometheus if config.enable_historical_metrics {x}] +
+    [ for x in prometheus if config.enable_historical_metrics && len(defaults.prometheus.external_host) == 0 {x} ] +
+	[ for x in prometheus_proxy if config.enable_historical_metrics && len(defaults.prometheus.external_host) > 0 {x} ] +
 	[ for x in openshift_spire if config.openshift && config.spire {x}]
 
-prometheus_manifests: [ for x in prometheus if config.enable_historical_metrics {x}]
+prometheus_manifests: [ for x in prometheus if config.enable_historical_metrics && len(defaults.prometheus.external_host) == 0 {x} ] +
+	[ for x in prometheus_proxy if config.enable_historical_metrics && len(defaults.prometheus.external_host) > 0 {x} ]
+
 
 // for CLI convenience,
 // e.g. `cue eval -c ./k8s/outputs --out text -e k8s_manifests_yaml`


### PR DESCRIPTION
…n; reuse mesh configs

This PR enables the operator to utilize an externally deployed prometheus server.  Manifests for the externally hosted prometheus can be found [here](https://github.com/greymatter-io/gists/tree/prometheus-external/external-prometheus).

## Prerequisties:
- a clean kubernetes cluster
- access to greymatter [gists](https://github.com/greymatter-io/gists/tree/prometheus-external/external-prometheus)
- A "metrics" namespace: `kubectl create ns metrics`

## Test with externally hosted prometheus (no tls)

### Stand up externally hosted prometheus

-  [external-prometheus-no-tls.yaml](https://github.com/greymatter-io/gists/blob/prometheus-external/external-prometheus/external-prometheus-no-tls.yaml)
- kc apply -f external-prometheus-no-tls.yaml
- You should see a `prometheus-0` pod in the "metrics" namespace.
- You should also see a kubernetes svc named prometheus.  To connect to this you will use the internal dns `prometheus.metrics.svc`
- prometheus is set up to use port 9090

### Connect Greymatter to externally hosted prometheus (no tls)

- Set up the operator to point to your test branch of gitops-core by adding the following argument to the to the operator manifest: `- -branch <your branch>`
- In inputs.cue set `defaults.prometheus.external_host: "prometheus.metrics.svc"`

EX:
```
defaults:
	prometheus:{
		external_host: "prometheus.metrics.svc"
		port: 9090
		tls:{
			enabled: false
			cert_secret: ""
		}
	}
```

- Start up the operator

> Success: You should see a deployment in the greymatter namespace `prometheus-<random string>` which is running the gm proxy.  You should be able to hit the dashboard and see historical metrics.

### Cleanup

- Tear down the operator
- `kubectl delete -f external-prometheus-no-tls.yaml`
- Ensure all pods in greymatter and metrics ns are torn down
- Ensure pvc is deleted in metrics namespace with: `kubectl delete $(kubectl get pvc | grep prometheus | awk '{print $1}')`


## Test with externally hosted prometheus (tls)

### Set up certs in metrics ns

- [Greymatter-ns-certs.yaml](https://github.com/greymatter-io/gists/blob/prometheus-external/external-prometheus/greymatter-ns-certs.yaml)
- [Metrics-ns-certs.yaml](https://github.com/greymatter-io/gists/blob/prometheus-external/external-prometheus/metrics-ns-certs.yaml)
- Run the following to set up these secrets: `kubectl apply -f  metrics-ns-certs.yaml` and `kubectl apply -f greymatter-ns-certs.yaml`
- You should see a `prometheus-certs` secret in both metrics and greymatter namespaces

### Deploy prometheus with certs

- [External-prometheus-tls.yaml](https://github.com/greymatter-io/gists/blob/prometheus-external/external-prometheus/external-prometheus-tls.yaml)
- Apply the manifest by running the following `kubectl apply -f external-prometheus-tls.yaml`
- The big difference in this file from the last one is that is adds a volume, volume mount, and an additional argument `--web.config.file` to the prometheus pod spec.
- You should see prometheus start up in the metrics namespace

### Connect Greymatter to externally hosted prometheus (tls)
- In inputs.cue set `defaults.prometheus.external_host: "prometheus.metrics.svc"`
- In inputs.cue set `defaults.prometheus.tls.enabled: true`
- In inputs.cue set `defaults.prometheus.tls.cert_secret: prometheus-certs`

EX:
```
defaults:
	prometheus:{
		external_host: "prometheus.metrics.svc"
		port: 9090
		tls:{
			enabled: true
			cert_secret: "prometheus-certs"
		}
	}
```
- Start up the operator

> Success: Same as non tls.

### Cleanup

- Tear down the operator
- `kubectl delete -f external-prometheus-tls.yaml`
- Ensure all pods in greymatter and metrics ns are torn down
- Ensure pvc is deleted in metrics namespace with: `kubectl delete $(kc get pvc | grep prometheus | awk '{print $1}')`
- Delete secrets with `kubectl delete secret prometheus-certs -n metrics && kubectl delete secret prometheus-certs -n greymatter`

## Test Greymatter managed prometheus

-  Deploy the operator and with the standard input.cue file
EX:
```
	prometheus:{
	
		external_host: ""
		port: 9090
		tls:{
			enabled: false
			cert_secret: ""
		}
	}
```

> Success: The mesh should stand up and you should be able to see historical metrics as normal.  Looking at kubernetes there should be a `prometheus-0` pod deployed into the `greymatter` namespace

