### PR TITLE
Add Bugsnag environment variable populated by secret

### DIFF
--- a/k8s/outputs/operator.cue
+++ b/k8s/outputs/operator.cue
@@ -211,6 +211,16 @@ operator_sts: [
             fsGroup: 1000
           }
           containers: [{
+              env: [{
+                name: "BUGSNAG_API_TOKEN"
+                valueFrom: {
+                  secretKeyRef: {
+                    name: "bugsnag-api-token"
+                    key: "token"
+                    optional: true
+                  }
+                }
+            }]
             if !config.debug {
               // command: ["sleep"] // DEBUG
               // args: ["30000"]


### PR DESCRIPTION
The operator needs to know our Bugsnag API token to report to the service. Hoisting that value into the code through environment variables requires a change to its k8s manifests to connect an environment variable to a k8s secret. This PR includes a env block that maps a statically defined secret name containing a bugsnag api token to an environment variable that the dev build of the operator expects to exist. Because the env var is set to optional (and the non-dev build does not contain any bugsnag code) a user (specifically non-internal end user) never needs to set it. 

Please evaluate the CUE to ensure it is valid

