### PR TITLE
update operator cue and input cue for new operator config

### DIFF
--- a/inputs.cue
+++ b/inputs.cue
@@ -7,12 +7,13 @@ import (
 
 config: {
 	// Flags
-	spire:                     bool | *false @tag(spire,type=bool)           // enable Spire-based mTLS
-	auto_apply_mesh:           bool | *true  @tag(auto_apply_mesh,type=bool) // apply the default mesh specified above after a delay
-	openshift:                 bool | *false @tag(openshift,type=bool)
-	enable_historical_metrics: bool | *true  @tag(enable_historical_metrics,type=bool)
-	debug:                     bool | *false @tag(debug,type=bool) // currently just controls k8s/outputs/operator.cue for debugging
-	test:                      bool | *false @tag(test,type=bool)  // currently just turns off GitOps so CI integration tests can manipulate directly
+	spire:                       bool | *false @tag(spire,type=bool)           // enable Spire-based mTLS
+	auto_apply_mesh:             bool | *true  @tag(auto_apply_mesh,type=bool) // apply the default mesh specified above after a delay
+	openshift:                   bool | *false @tag(openshift,type=bool)
+	enable_historical_metrics:   bool | *true  @tag(enable_historical_metrics,type=bool)
+	debug:                       bool | *false @tag(debug,type=bool) // currently just controls k8s/outputs/operator.cue for debugging
+	test:                        bool | *false @tag(test,type=bool)  // currently just turns off GitOps so CI integration tests can manipulate directly
+	auto_copy_image_pull_secret: bool | *true @tag(auto_copy_iamge_pull_secret, type=bool)
 
 	// for a hypothetical future where we want to mount specific certificates for operator webhooks, etc.
 	generate_webhook_certs: bool | *true        @tag(generate_webhook_certs,type=bool)

--- a/k8s/outputs/operator.cue
+++ b/k8s/outputs/operator.cue
@@ -354,6 +354,7 @@ operator_k8s: [
         auto_apply_mesh: \(config.auto_apply_mesh)
         openshift: \(config.openshift)
         generate_webhook_certs: \(config.generate_webhook_certs)
+        auto_copy_image_pull_secret: \(config.auto_copy_image_pull_secret)
       }
       """
     }


### PR DESCRIPTION
This is a companion pr to (https://github.com/greymatter-io/operator/pull/148) change to the operator which adds a config.  

 `auto_copy_image_pull_secret` settings:
- `true` will have the standard feature which will copy the image pull secret from the gm-operator namespace into the install namespace as well as any watch namespaces
- `false` will not copy the image pull secret.  The operator does log if it can not find the secret.

> The operator will still create all resources required for greymatter core however these will fail to start until an image pull of name `gm-docker-secret` is added to the namespace.

Refer to companion pr for testing instructions.