### PR TITLE
Clean export prometheus rules

### DIFF
--- a/k8s/outputs/EXTRACTME.cue
+++ b/k8s/outputs/EXTRACTME.cue
@@ -35,6 +35,7 @@ prometheus_manifests: [ for x in prometheus if config.enable_historical_metrics 
 	[ for x in prometheus_proxy if config.enable_historical_metrics && len(defaults.prometheus.external_host) > 0 {x} ]
 
 prometheus_scrape_rules: prometheus[len(prometheus)-1]
+prometheus_rbac: prometheus[1:len(prometheus)-1]
 
 // for CLI convenience,
 // e.g. `cue eval -c ./k8s/outputs --out text -e k8s_manifests_yaml`
@@ -44,6 +45,7 @@ spire_manifests_yaml: yaml.MarshalStream(spire_manifests)
 k8s_manifests_yaml: yaml.MarshalStream(k8s_manifests)
 prometheus_manifests_yaml: yaml.MarshalStream(prometheus_manifests)
 prometheus_scrape_rules_yaml: yaml.Marshal(prometheus_scrape_rules)
+prometheus_rbac_yaml: yaml.MarshalStream(prometheus_rbac)
 
 // TODO this was only necessary because I don't know how to pass _Name into #sidecar_container_block
 // from Go. Then I decided to kill two birds with one stone and also put the sidecar_socket_volume in there.

--- a/k8s/outputs/EXTRACTME.cue
+++ b/k8s/outputs/EXTRACTME.cue
@@ -34,6 +34,7 @@ k8s_manifests: controlensemble +
 prometheus_manifests: [ for x in prometheus if config.enable_historical_metrics && len(defaults.prometheus.external_host) == 0 {x} ] +
 	[ for x in prometheus_proxy if config.enable_historical_metrics && len(defaults.prometheus.external_host) > 0 {x} ]
 
+prometheus_scrape_rules: prometheus[len(prometheus)-1]
 
 // for CLI convenience,
 // e.g. `cue eval -c ./k8s/outputs --out text -e k8s_manifests_yaml`
@@ -42,6 +43,7 @@ all_but_operator_manifests_yaml: yaml.MarshalStream(all_but_operator_manifests)
 spire_manifests_yaml: yaml.MarshalStream(spire_manifests)
 k8s_manifests_yaml: yaml.MarshalStream(k8s_manifests)
 prometheus_manifests_yaml: yaml.MarshalStream(prometheus_manifests)
+prometheus_scrape_rules_yaml: yaml.Marshal(prometheus_scrape_rules)
 
 // TODO this was only necessary because I don't know how to pass _Name into #sidecar_container_block
 // from Go. Then I decided to kill two birds with one stone and also put the sidecar_socket_volume in there.


### PR DESCRIPTION
…us for us.

This will provide an up to date clean way for us to provide someone managing an external prometheus the info they need to set it up to scrape greymatter.

EX:
To get a base set of rules prometheus needs to scrape greymatter run `cue eval -c ./k8s/outputs -e prometheus_scrape_rules_yaml --out text > prometheus-rules.yaml` this will result in a config map where you can see the rules we apply to our prometheus instances.

To see a list of kuberenetes RBAC permissions we set run `cue eval -c ./k8s/outputs -e prometheus_rbac_yaml --out text > prometheus-rbac.yaml`

