### PR TITLE
Match operator debug command arguments with release command arguments

### DIFF
--- a/k8s/outputs/operator.cue
+++ b/k8s/outputs/operator.cue
@@ -256,8 +256,12 @@ operator_sts: [
                 "--accept-multiclient",
                 "--api-version=2",
                 "exec",
+                "--continue",
                 "/app/operator",
-                "-cueRoot", "core",
+                "--",
+                "-repo", "git@github.com:greymatter-io/gitops-core.git",
+                "-sshPrivateKeyPath", "/app/.ssh/id_ed25519",
+                "-tag", "v0.9.3"
               ]
               imagePullPolicy: "Always"
             }


### PR DESCRIPTION
Now that the debug container will become the default development container, it needs to match the behaviors and functionalities of the normal build. 

To test, look at the jack.k8s.local kops cluster. Describe the operator pod, look that the debug image is running and the cmd args contain the values listed in the PR. Confirm that the operator is running successfully. 