### PR TITLE
add resource blocks to all deployments and stateful sets

### DIFF
--- a/k8s/intermediates.cue
+++ b/k8s/intermediates.cue
@@ -33,6 +33,17 @@ import (
 			{name: "SPIRE_PATH", value: "/run/spire/socket/agent.sock"}
 		},
 	]
+	resources: {
+		limits: {  
+			cpu: *"200m" | string
+			memory: *"512Mi" | string
+		}
+		requests: {
+			cpu: *"50m" | string
+			memory: *"128Mi" | string
+		}
+		
+	}
 	volumeMounts:    #sidecar_volume_mounts + _volume_mounts
 	imagePullPolicy: defaults.image_pull_policy
 }
@@ -65,3 +76,4 @@ import (
 	}
 	...
 }
+

--- a/k8s/outputs/catalog.cue
+++ b/k8s/outputs/catalog.cue
@@ -47,6 +47,11 @@ catalog: [
 								{name: "REDIS_PORT", value: "6379"},
 								{name: "REDIS_DB", value:   "0"},
 							]
+							resources: {
+								limits: { cpu: "200m", memory: "1Gi" }
+								requests: { cpu: "50m", memory: "128Mi"}
+								
+							}
 							imagePullPolicy: defaults.image_pull_policy
 							volumeMounts: [
 								{

--- a/k8s/outputs/controlensemble.cue
+++ b/k8s/outputs/controlensemble.cue
@@ -53,6 +53,10 @@ controlensemble: [
 								{name: "GM_CONTROL_API_ZONE_NAME", value:            mesh.spec.zone},
 								{name: "GM_CONTROL_DIFF_IGNORE_CREATE", value:       "true"},
 							]
+							resources: {
+								limits: { cpu: "500m", memory: "1Gi" }
+								requests: { cpu: "125m", memory: "256Mi" }
+							}
 							imagePullPolicy: defaults.image_pull_policy
 						}, // control
 
@@ -77,6 +81,10 @@ controlensemble: [
 								{name: "GM_CONTROL_API_REDIS_PORT", value: "6379"}, // local redis in this pod
 								{name: "GM_CONTROL_API_REDIS_DB", value:   "0"},
 							]
+							resources: {
+								limits: { cpu: "1", memory: "1Gi" }
+								requests: { cpu: "250m", memory: "256Mi" }
+							}
 							imagePullPolicy: defaults.image_pull_policy
 						}, // control_api
 

--- a/k8s/outputs/dashboard.cue
+++ b/k8s/outputs/dashboard.cue
@@ -49,6 +49,10 @@ dashboard: [
 								{name: "KEYCLOAK_CLIENT_SECRET", value:       "\(defaults.edge.oidc.client_secret)"},
 								{name: "KEYCLOAK_AUTH_URL", value:            "\(defaults.edge.oidc.endpoint)/auth/realms/\(defaults.edge.oidc.realm)/protocol/openid-connect/token"},
 							]
+							resources: {
+								limits: { cpu: "1", memory: "2Gi" }
+								requests: { cpu: "500m", memory: "1Gi" }
+							}
 							volumeMounts: [
 								{
 									name:      "feature-flag-config"

--- a/k8s/outputs/edge.cue
+++ b/k8s/outputs/edge.cue
@@ -33,6 +33,10 @@ edge: [
 									}
 								},
 							]
+							resources: {
+								limits: { cpu: "1", memory: "1Gi" }
+								requests: { cpu: "250m", memory: "128Mi" }
+							}
 						},
 					]
 					volumes: #sidecar_volumes + [

--- a/k8s/outputs/prometheus.cue
+++ b/k8s/outputs/prometheus.cue
@@ -69,14 +69,9 @@ prometheus: [
 								},
 							]
 							resources: {
-								requests: {
-									memory: "8Gi"
-									cpu:    "1"
-								}
-								limits: {
-									memory: "12Gi"
-									cpu:    "2"
-								}
+								limits: { cpu: "2", memory: "8Gi" }
+								requests: { cpu: "1", memory: "4Gi" }
+								
 							}
 						},
 

--- a/k8s/outputs/redis.cue
+++ b/k8s/outputs/redis.cue
@@ -45,6 +45,10 @@ redis: [
 								"--dir", "/data",
 								"--logLevel", "verbose",
 							]
+							resources: {
+								limits: { cpu: "200m", memory: "500Mi" }
+								requests: { cpu: "50m", memory: "128Mi" }
+							}
 							ports: [{// HACK this port is exposed so the Service (below) can get to it for easy bootstrap
 								name:          "redis"
 								containerPort: 6379

--- a/k8s/outputs/spire.cue
+++ b/k8s/outputs/spire.cue
@@ -99,7 +99,10 @@ spire_server: [
               name:      "server-data" // Mounted from PVC
               mountPath: "/run/spire/data"
             }]
-            resources: {}
+            resources: {
+              limits: { cpu: "1", memory: "1Gi" }
+              requests: { cpu: "500m", memory: "512Mi" }
+            }
           }, {
             name:            "registrar"
             image:           "gcr.io/spiffe-io/k8s-workload-registrar:1.2.0"
@@ -121,7 +124,10 @@ spire_server: [
               name:      "server-socket"
               mountPath: "/run/spire/socket"
             }]
-            resources: {}
+            resources: {
+              limits: { cpu: "1", memory: "1Gi" }
+              requests: { cpu: "500m", memory: "512Mi" }
+            }
           }]
           volumes: [{
             name: "server-socket"
@@ -391,7 +397,10 @@ spire_agent: [
               name:      "agent-token"
               mountPath: "/run/spire/token"
             }]
-            resources: {}
+            resources: { 
+              limits: { cpu: "1", memory: "1Gi" }
+              requests: { cpu: "500m", memory: "512Mi" }
+            }
           }]
           volumes: [{
             name: "agent-config"


### PR DESCRIPTION
[sc-20865]

This PR adds resource blocks to all deployments and stateful sets.

## Testing

Setup your operator.yaml file to point to this branch and `kubectl apply -f operator.yaml` when the pods are stood up you should be able to see the dashboard.

Looking at the yaml for each pod you will see a resource block for all containers in each pod.