### PR TITLE
Resource reduction

### DIFF
--- a/k8s/outputs/controlensemble.cue
+++ b/k8s/outputs/controlensemble.cue
@@ -54,7 +54,7 @@ controlensemble: [
 								{name: "GM_CONTROL_DIFF_IGNORE_CREATE", value:       "true"},
 							]
 							resources: {
-								limits: { cpu: "500m", memory: "1Gi" }
+								limits: { cpu: "200m", memory: "1Gi" }
 								requests: { cpu: "125m", memory: "256Mi" }
 							}
 							imagePullPolicy: defaults.image_pull_policy
@@ -82,7 +82,7 @@ controlensemble: [
 								{name: "GM_CONTROL_API_REDIS_DB", value:   "0"},
 							]
 							resources: {
-								limits: { cpu: "1", memory: "1Gi" }
+								limits: { cpu: "400m", memory: "512Mi" }
 								requests: { cpu: "250m", memory: "256Mi" }
 							}
 							imagePullPolicy: defaults.image_pull_policy

--- a/k8s/outputs/dashboard.cue
+++ b/k8s/outputs/dashboard.cue
@@ -50,8 +50,8 @@ dashboard: [
 								{name: "KEYCLOAK_AUTH_URL", value:            "\(defaults.edge.oidc.endpoint)/auth/realms/\(defaults.edge.oidc.realm)/protocol/openid-connect/token"},
 							]
 							resources: {
-								limits: { cpu: "1", memory: "2Gi" }
-								requests: { cpu: "500m", memory: "1Gi" }
+								limits: { cpu: "200m", memory: "1Gi" }
+								requests: { cpu: "100m", memory: "500Mi" }
 							}
 							volumeMounts: [
 								{

--- a/k8s/outputs/edge.cue
+++ b/k8s/outputs/edge.cue
@@ -34,8 +34,8 @@ edge: [
 								},
 							]
 							resources: {
-								limits: { cpu: "1", memory: "1Gi" }
-								requests: { cpu: "250m", memory: "128Mi" }
+								limits: { cpu: "200m", memory: "200Mi" }
+								requests: { cpu: "100m", memory: "128Mi" }
 							}
 						},
 					]

--- a/k8s/outputs/prometheus.cue
+++ b/k8s/outputs/prometheus.cue
@@ -69,8 +69,8 @@ prometheus: [
 								},
 							]
 							resources: {
-								limits: { cpu: "2", memory: "8Gi" }
-								requests: { cpu: "1", memory: "4Gi" }
+								limits: { cpu: "500m", memory: "2Gi" }
+								requests: { cpu: "200m", memory: "1Gi" }
 								
 							}
 						},

--- a/k8s/outputs/spire.cue
+++ b/k8s/outputs/spire.cue
@@ -100,8 +100,8 @@ spire_server: [
               mountPath: "/run/spire/data"
             }]
             resources: {
-              limits: { cpu: "1", memory: "1Gi" }
-              requests: { cpu: "500m", memory: "512Mi" }
+              limits: { cpu: "350m", memory: "1Gi" }
+              requests: { cpu: "100m", memory: "512Mi" }
             }
           }, {
             name:            "registrar"
@@ -125,8 +125,8 @@ spire_server: [
               mountPath: "/run/spire/socket"
             }]
             resources: {
-              limits: { cpu: "1", memory: "1Gi" }
-              requests: { cpu: "500m", memory: "512Mi" }
+              limits: { cpu: "400m", memory: "1Gi" }
+              requests: { cpu: "100m", memory: "512Mi" }
             }
           }]
           volumes: [{
@@ -398,8 +398,8 @@ spire_agent: [
               mountPath: "/run/spire/token"
             }]
             resources: { 
-              limits: { cpu: "1", memory: "1Gi" }
-              requests: { cpu: "500m", memory: "512Mi" }
+              limits: { cpu: "400m", memory: "512Mi" }
+              requests: { cpu: "200m", memory: "256Mi" }
             }
           }]
           volumes: [{


### PR DESCRIPTION
A recent addition of resource definitions assumed much larger resource pools than necessary. For example, the mesh could start in our integration test clusters before the change, but could not after the change. This PR reduces the resources until spire and the mesh could start up again. 

This operator pr uses this branch:
https://github.com/greymatter-io/operator/pull/147/files/793b8751b876bd4293cad2dc21270e82af7b4c4c..bc743e0f3f9a143c78ff9ae562f3daa387783ef0

go to the recently built pipeline:
https://buildkite.com/greymatter/operator/builds/991

 Notice how the spire tests fails after verifying the pods are alive (this is a known issue with spire not receiving ids. if it was resource related, the script would timeout waiting for the pods to start)