### PR TITLE
Add JWTSecurity Filter and Service Toggle

### DIFF
--- a/gm/outputs/EXTRACTME.cue
+++ b/gm/outputs/EXTRACTME.cue
@@ -5,16 +5,22 @@ package greymatter
 
 import "encoding/yaml"
 
+_enable_jwtsecurity: *false | bool
+if defaults.jwtsecurity != _|_ {
+	_enable_jwtsecurity: defaults.jwtsecurity
+}
+
 mesh_configs: redis_config +
-             edge_config +
-             catalog_config +
-             controlensemble_config +
-             dashboard_config +
-             catalog_entries +
-             [for x in prometheus_config if config.enable_historical_metrics {x} ]
+	edge_config +
+	catalog_config +
+	controlensemble_config +
+	dashboard_config +
+	catalog_entries +
+	[ for x in prometheus_config if config.enable_historical_metrics {x}] +
+		[ for x in jwtsecurity_config if _enable_jwtsecurity {x}]
 redis_listener: redis_listener_object // special because we need to re-apply it when Spire is enabled for every new sidecar
 
-prometheus_mesh_configs: [for x in prometheus_config if config.enable_historical_metrics {x} ] + catalog_entries
+prometheus_mesh_configs: [ for x in prometheus_config if config.enable_historical_metrics {x}] + catalog_entries
 
 // for CLI convenience,
 // e.g. `cue eval -c ./gm/outputs --out text -e mesh_configs_yaml`

--- a/gm/outputs/jwtsecurity.cue
+++ b/gm/outputs/jwtsecurity.cue
@@ -1,0 +1,68 @@
+// Grey Matter configuration for jwt_security's sidecar
+
+package greymatter
+
+let Name = "jwt-security"
+let JWTsecurityIngressName = "\(Name)_local"
+let EgressToRedisName = "\(Name)_egress_to_redis"
+
+jwtsecurity_config: [
+
+	// jwtsecurity HTTP ingress
+	#domain & {domain_key: JWTsecurityIngressName},
+	#listener & {
+		listener_key:          JWTsecurityIngressName
+		_spire_self:           Name
+		_gm_observables_topic: Name
+		_is_ingress:           true
+	},
+	#cluster & {cluster_key: JWTsecurityIngressName, _upstream_port: 8080},
+	#route & {route_key:     JWTsecurityIngressName},
+
+	// egress -> Metrics redis
+	#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
+	#cluster & {
+		cluster_key:  EgressToRedisName
+		name:         defaults.redis_cluster_name
+		_spire_self:  Name
+		_spire_other: defaults.redis_cluster_name
+	},
+	// unused route must exist for the cluster to be registered with sidecar
+	#route & {route_key: EgressToRedisName},
+	#listener & {
+		listener_key: EgressToRedisName
+		// egress listeners are local-only
+		ip:            "127.0.0.1"
+		port:          defaults.ports.redis_ingress
+		_tcp_upstream: defaults.redis_cluster_name
+	},
+
+	// shared proxy object
+	#proxy & {
+		proxy_key: Name
+		domain_keys: [JWTsecurityIngressName, EgressToRedisName]
+		listener_keys: [JWTsecurityIngressName, EgressToRedisName]
+	},
+
+	// Edge config for jwtsecurity ingress
+	#cluster & {
+		cluster_key:  Name
+		_spire_other: Name
+	},
+	#route & {
+		domain_key: defaults.edge.key
+		route_key:  Name
+		route_match: {
+			path: "/services/jwtsecurity/"
+		}
+		redirects: [
+			{
+				from:          "^/services/jwtsecurity$"
+				to:            route_match.path
+				redirect_type: "permanent"
+			},
+		]
+		prefix_rewrite: "/"
+	},
+
+]

--- a/inputs.cue
+++ b/inputs.cue
@@ -7,7 +7,7 @@ import (
 
 config: {
 	// Flags
-	spire:                       bool | *false           @tag(spire,type=bool)           // enable Spire-based mTLS
+	spire:                       bool | *false           @tag(spire,type=bool) // enable Spire-based mTLS
 	openshift:                   bool | *false           @tag(openshift,type=bool)
 	enable_historical_metrics:   bool | *true            @tag(enable_historical_metrics,type=bool)
 	debug:                       bool | *false           @tag(debug,type=bool) // currently just controls k8s/outputs/operator.cue for debugging
@@ -30,13 +30,14 @@ mesh: meshv1.#Mesh & {
 		release_version:   string | *"1.7" // deprecated
 		zone:              string | *"default-zone"
 		images: {
-			proxy:       string | *"quay.io/greymatterio/gm-proxy:1.7.1"
-			catalog:     string | *"quay.io/greymatterio/gm-catalog:3.0.5"
-			dashboard:   string | *"quay.io/greymatterio/gm-dashboard:connections"
-			control:     string | *"quay.io/greymatterio/gm-control:1.7.3"
-			control_api: string | *"quay.io/greymatterio/gm-control-api:1.7.3"
-			redis:       string | *"redis:latest"
-			prometheus:  string | *"prom/prometheus:v2.36.2"
+			proxy:        string | *"quay.io/greymatterio/gm-proxy:1.7.1"
+			catalog:      string | *"quay.io/greymatterio/gm-catalog:3.0.5"
+			dashboard:    string | *"quay.io/greymatterio/gm-dashboard:connections"
+			control:      string | *"quay.io/greymatterio/gm-control:1.7.3"
+			control_api:  string | *"quay.io/greymatterio/gm-control-api:1.7.3"
+			redis:        string | *"redis:latest"
+			prometheus:   string | *"prom/prometheus:v2.36.2"
+			jwt_security: string | *"quay.io/greymatterio/gm-jwt-security:1.3.1"
 		}
 	}
 }
@@ -45,7 +46,6 @@ defaults: {
 	image_pull_secret_name:   string | *"gm-docker-secret"
 	image_pull_policy:        corev1.#enumPullPolicy | *corev1.#PullAlways
 	xds_host:                 "controlensemble.\(mesh.spec.install_namespace).svc.cluster.local"
-	sidecar_list:             [...string] | *["dashboard", "catalog", "controlensemble", "edge"]
 	proxy_port_name:          "proxy" // the name of the ingress port for sidecars - used by service discovery
 	redis_cluster_name:       "redis"
 	redis_host:               "\(redis_cluster_name).\(mesh.spec.install_namespace).svc.cluster.local"
@@ -54,8 +54,10 @@ defaults: {
 	redis_username:           ""
 	redis_password:           ""
 	gitops_state_key_gm:      "gmHashes"  // the key in Redis for Grey Matter applied-state backups
-  gitops_state_key_k8s:     "k8sHashes" // the key in Redis for K8s applied-state backups
-  gitops_state_key_sidecar: "k8sHashes" // the key in Redis for K8s applied-state backups
+	gitops_state_key_k8s:     "k8sHashes" // the key in Redis for K8s applied-state backups
+	gitops_state_key_sidecar: "k8sHashes" // the key in Redis for K8s applied-state backups
+	spire_selinux_context:    string | *"s0:c30,c5"
+	sidecar_list:             [...string] | *["dashboard", "catalog", "controlensemble", "edge", "jwtsecurity"]
 
 	ports: {
 		default_ingress: 10808

--- a/k8s/intermediates.cue
+++ b/k8s/intermediates.cue
@@ -34,15 +34,15 @@ import (
 		},
 	]
 	resources: {
-		limits: {  
-			cpu: *"200m" | string
+		limits: {
+			cpu:    *"200m" | string
 			memory: *"512Mi" | string
 		}
 		requests: {
-			cpu: *"50m" | string
+			cpu:    *"50m" | string
 			memory: *"128Mi" | string
 		}
-		
+
 	}
 	volumeMounts:    #sidecar_volume_mounts + _volume_mounts
 	imagePullPolicy: defaults.image_pull_policy
@@ -76,4 +76,3 @@ import (
 	}
 	...
 }
-

--- a/k8s/outputs/jwtsecurity.cue
+++ b/k8s/outputs/jwtsecurity.cue
@@ -1,0 +1,93 @@
+// Manifests for the jwt_security pod
+
+package greymatter
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+let Name = "jwt-security"
+jwt_security: [
+	appsv1.#Deployment & {
+		apiVersion: "apps/v1"
+		kind:       "Deployment"
+		metadata: {
+			name:      Name
+			namespace: mesh.spec.install_namespace
+		}
+		spec: {
+			selector: {
+				matchLabels: {"greymatter.io/cluster": Name}
+			}
+			template: {
+				metadata: {
+					labels: {
+						"greymatter.io/cluster":  Name
+						"greymatter.io/workload": "\(mesh.metadata.name).\(Name)"
+					}
+				}
+				spec: #spire_permission_requests & {
+					containers: [
+						#sidecar_container_block & {_Name: Name},
+						{
+							name:  Name
+							image: mesh.spec.images.jwt_security
+							ports: [{
+								name:          "http"
+								containerPort: 8080
+							}]
+							env: [
+								// This needs to be present in order to disable redis caching. 
+								{
+									name:  "REDIS_HOST"
+									value: ""
+								},
+								{
+									name:  "HTTP_PORT"
+									value: "8080"
+								},
+								{
+									name:  "ENABLE_TLS"
+									value: "false"
+								},
+								{
+									name: "JWT_API_KEY"
+									valueFrom: {
+										secretKeyRef: {
+											name: "jwt-api-key"
+											key:  "value"
+										}
+									}
+								},
+								{
+									name: "PRIVATE_KEY"
+									valueFrom: {
+										secretKeyRef: {
+											name: "jwt-private-key"
+											key:  "value"
+										}
+									}
+								},
+								{
+									name: "USERS_JSON"
+									valueFrom: {
+										secretKeyRef: {
+											name: "jwt-users-json"
+											key:  "value"
+										}
+									}
+								},
+							]
+							resources: {
+								requests: {cpu: "50m", memory: "128Mi"}
+							}
+							imagePullPolicy: defaults.image_pull_policy
+						},
+					]
+					volumes: #sidecar_volumes
+					imagePullSecrets: [{name: defaults.image_pull_secret_name}]
+				}
+			}
+		}
+	},
+]


### PR DESCRIPTION
[sc-20732]
[sc-24282]

This is a two-pronged review because the commits include code to verify the filter is working. After a reviewer confirms the filter works as intended, then I'll have to remove that code. The testing code is found in the edge.cue file. 

The gist of this PR is to add a toggle to deploy the jwtsecurity service with some configuration set in the inputs.cue (so users dont need to delve into the k8s cue), and to add a toggle to enable the http filter. There is also a "helper object" to easily connect the sidecar proxy with the enabled filter to jwtsecurity. This is a similar pattern to what I did with ext_authz and OPA. 

To test:
I have a kops cluster running an operator pulling configurations from this branch. The edge proxy has the filter enabled. To connect to it:
```
awsume bs-resources-admin
kops export kubeconfig jack.k8s.local --admin
```
Run `kubectl get pods -n greymatter`
Confirm that all services are running and jwtsecurity is among them

Attach to the edge logs:
`kubectl logs -n greymatter edge-54d89bd875-grgfq -f`

We will send a curl request through the edge and watch it log the forwarded request with the x-jwt-token header included.
`curl -v -s -o /dev/null -H "USER_DN: CN=localuser,OU=Engineering,O=Decipher Technology Studios,=Alexandria,=Virginia,C=US" http://a666bc95fb6484a61879159884ce4e13-942645687.us-east-1.elb.amazonaws.com:10808/services/catalog/summary`

Make sure the actual request succeeded. 

In the edge log, you should see  an object starting with `eventId` and contains information about the request, including (if the filter worked) a populated `"x-jwt-token"` key. 

