### PR TITLE
Add new oidc configuration options and legacy keycloak toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## vNEXT
+
+### Added
+
+- Updated `gm_oidc-authentication` filter to support pre/post Keycloak v17 
+
 ## 0.10.0 (September 13, 2022)
 
 ### Changed

--- a/gm/outputs/edge.cue
+++ b/gm/outputs/edge.cue
@@ -22,7 +22,6 @@ edge_config: [
 		_enable_ext_authz:           false
 		_oidc_endpoint:              defaults.edge.oidc.endpoint
 		_oidc_service_url:           "https://\(defaults.edge.oidc.domain):\(defaults.ports.edge_ingress)"
-		_oidc_provider:              "\(defaults.edge.oidc.endpoint)/auth/realms/\(defaults.edge.oidc.realm)"
 		_oidc_client_id:             defaults.edge.oidc.client_id
 		_oidc_client_secret:         defaults.edge.oidc.client_secret
 		_oidc_cookie_domain:         defaults.edge.oidc.domain

--- a/inputs.cue
+++ b/inputs.cue
@@ -129,7 +129,6 @@ defaults: {
 			realm:         ""
 			jwt_authn_provider: {
 				keycloak: {
-					issuer: "\(endpoint)/auth/realms/\(realm)"
 					audiences: ["\(defaults.edge.key)"]
 					local_jwks: {
 						inline_string: #"""
@@ -141,7 +140,6 @@ defaults: {
 					// in ./gm/outputs/edge.cue that you will also need to uncomment.
 					// remote_jwks: {
 					//  http_uri: {
-					//   uri:     "\(endpoint)/auth/realms/\(realm)/protocol/openid-connect/certs"
 					//   cluster: "edge_to_keycloak" // this key should be unique across the mesh
 					//  }
 					// }

--- a/k8s/outputs/dashboard.cue
+++ b/k8s/outputs/dashboard.cue
@@ -5,6 +5,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+_authRealms: string | *"/realms/"
+if defaults.edge.oidc.keycloak_pre_17 != _|_ {
+	if defaults.edge.oidc.keycloak_pre_17 {
+		_authRealms: "/auth/realms/"
+	}
+
+}
+
 let Name = "dashboard"
 dashboard: [
 
@@ -22,7 +30,7 @@ dashboard: [
 			template: {
 				metadata: {
 					labels: {
-						"greymatter.io/cluster": Name
+						"greymatter.io/cluster":  Name
 						"greymatter.io/workload": "\(config.operator_namespace).\(mesh.metadata.name).\(Name)"
 					}
 				}
@@ -50,11 +58,11 @@ dashboard: [
 								{name: "REDIS_PORT", value:                   "6379"},
 								{name: "KEYCLOAK_CLIENT_ID", value:           "\(defaults.edge.oidc.client_id)"},
 								{name: "KEYCLOAK_CLIENT_SECRET", value:       "\(defaults.edge.oidc.client_secret)"},
-								{name: "KEYCLOAK_AUTH_URL", value:            "\(defaults.edge.oidc.endpoint)/auth/realms/\(defaults.edge.oidc.realm)/protocol/openid-connect/token"},
+								{name: "KEYCLOAK_AUTH_URL", value:            "\(defaults.edge.oidc.endpoint)\(_authRealms)\(defaults.edge.oidc.realm)/protocol/openid-connect/token"},
 							]
 							resources: {
-								limits: { cpu: "200m", memory: "1Gi" }
-								requests: { cpu: "100m", memory: "500Mi" }
+								limits: {cpu: "200m", memory: "1Gi"}
+								requests: {cpu: "100m", memory: "500Mi"}
 							}
 							volumeMounts: [
 								{


### PR DESCRIPTION
This allows the intermediate definition to track the actual generated definitions from the proxy. In particular, this allows the user to access the authRealms and authAdminRealms fields necessary for keycloak backwards compatibility. The user can toggle between pre-v17 and v17+ configurations by using the keycloak_pre_17 field in the inputs defaults.edge.oidc struct. 

**Syntax Testing** 
1. Evaluate the CUE. Ensure that the two new fields have the default values (do not contain "auth")
2. Turn on keycloak_pre_17 in inputs.cue. Evaluate the CUE and confirm that the new fields do contain "auth". Ensure the provider field also contains "auth" in the url path.

**Functional Testing**
I created a kops cluster, jack.k8s.local, with an operator configured to pull changes from the [gocloak-test](https://github.com/greymatter-io/gitops-core/tree/gocloak-test) branch.

```
awsume bs-resources-admin
kops export kubeconfig jack.k8s.local --admin
# Confirm that the operator is watching that branch
kubectl get pods -n gm-operator greymatter-operator-0 -o yaml | grep "branch" -A 1
```
Checkout the gitops-core gocloak-test branch.

Make sure the edge redirects you to keycloak: `https://aaaa6d4794460416fb09dd7b1fed5c5a-245909094.us-east-1.elb.amazonaws.com:10808` (Chrome based browsers may not let you load the site with insecure certs. I used firefox and it worked.) If it does, this means that the oidc-auth filter supports keycloak v17+.

Open the edge.cue file and add  `keycloak_pre_17: true` to the listener. 
Commit and push.
Run `greymatter get listener -k edge` and ensure it contains the legacy field values 
Try and access the dashboard again. You should receive and error, since the path is not incorrect for keycloak 17+. 
