### PR TITLE
remove operator namespace from operator.yaml

### DIFF
--- a/operator.yaml
+++ b/operator.yaml
@@ -1,12 +1,5 @@
 metadata:
   labels:
-    name: gm-operator
-  name: gm-operator
-kind: Namespace
-apiVersion: v1
----
-metadata:
-  labels:
     name: greymatter-operator
   name: greymatter-operator
   namespace: gm-operator


### PR DESCRIPTION
Since we instruct users to create the operator namespace manually in [](), this config is not needed. By removing it we prevent the below message when running `kubectl apply -f operator.yaml`. The message is more of an annoyance than anything because there's no negative impact.

```
Warning: resource namespaces/gm-operator is missing the [kubectl.kubernetes.io/last-applied-configuration](http://kubectl.kubernetes.io/last-applied-configuration) annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
```