### PR TITLE
Enable mtls connections for all internal core components

### DIFF
--- a/gm/outputs/EXTRACTME.cue
+++ b/gm/outputs/EXTRACTME.cue
@@ -24,6 +24,15 @@ redis_listener: redis_listener_object // special because we need to re-apply it 
 
 prometheus_mesh_configs: [ for x in prometheus_config if config.enable_historical_metrics {x}] + catalog_entries
 
+edge_configs: edge_config
+dashboard_configs: dashboard_config
+catalog_configs: catalog_config
+controlensemble_configs: controlensemble_config
+prometheus_configs: prometheus_config
+redis_configs: redis_config
+observables_configs: observables_config
+jwtsecurity_configs: jwtsecurity_config
+
 // for CLI convenience,
 // e.g. `cue eval -c ./gm/outputs --out text -e mesh_configs_yaml`
 mesh_configs_yaml: yaml.MarshalStream(mesh_configs)

--- a/gm/outputs/catalog.cue
+++ b/gm/outputs/catalog.cue
@@ -3,13 +3,15 @@
 package greymatter
 
 let Name = "catalog"
-let CatalogIngressName = "\(Name)_local"
+let CatalogIngressName = "\(Name)_ingress"
 let EgressToRedisName = "\(Name)_egress_to_redis"
 
 catalog_config: [
 
 	// Catalog HTTP ingress
-	#domain & {domain_key: CatalogIngressName},
+	#domain & {
+    domain_key: CatalogIngressName
+  },
 	#listener & {
 		listener_key:          CatalogIngressName
 		_spire_self:           Name
@@ -20,7 +22,10 @@ catalog_config: [
 	#route & {route_key:     CatalogIngressName},
 
 	// egress -> redis
-	#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
+	#domain & {
+    domain_key: EgressToRedisName
+    port: defaults.ports.redis_ingress
+  },
 	#cluster & {
 		cluster_key:  EgressToRedisName
 		name:         defaults.redis_cluster_name

--- a/gm/outputs/controlensemble.cue
+++ b/gm/outputs/controlensemble.cue
@@ -9,7 +9,9 @@ let EgressToRedisName = "\(Name)_egress_to_redis"
 controlensemble_config: [
 
 	// Control API HTTP ingress
-	#domain & {domain_key: ControlAPIIngressName},
+	#domain & {
+    domain_key: ControlAPIIngressName
+  },
 	#listener & {
 		listener_key:          ControlAPIIngressName
 		_spire_self:           Name
@@ -20,7 +22,10 @@ controlensemble_config: [
 	#route & {route_key:     ControlAPIIngressName},
 
 	// egress->redis
-	#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
+	#domain & {
+    domain_key: EgressToRedisName
+    port: defaults.ports.redis_ingress
+  },
 	#cluster & {
 		cluster_key:  EgressToRedisName
 		name:         defaults.redis_cluster_name

--- a/gm/outputs/dashboard.cue
+++ b/gm/outputs/dashboard.cue
@@ -3,12 +3,14 @@
 package greymatter
 
 let Name = "dashboard"
-let LocalName = "dashboard_local"
+let LocalName = "\(Name)_ingress"
 let EgressToRedisName = "\(Name)_egress_to_redis"
 
 dashboard_config: [
 	// sidecar -> dashboard
-	#domain & {domain_key: LocalName},
+	#domain & {
+    domain_key: LocalName
+  },
 	#listener & {
 		listener_key:          LocalName
 		_spire_self:           Name
@@ -19,7 +21,10 @@ dashboard_config: [
 	#route & {route_key:     LocalName},
 
 	// egress -> redis
-	#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
+	#domain & {
+    domain_key: EgressToRedisName
+    port: defaults.ports.redis_ingress
+  },
 	#cluster & {
 		cluster_key:  EgressToRedisName
 		name:         defaults.redis_cluster_name

--- a/gm/outputs/edge.cue
+++ b/gm/outputs/edge.cue
@@ -8,9 +8,13 @@ let EgressToRedisName = "\(defaults.edge.key)_egress_to_redis"
 // let EdgeToKeycloakName = defaults.edge.oidc.jwt_authn_provider.keycloak.remote_jwks.http_uri.cluster
 
 edge_config: [
+	// This domain is special because it uses edge certs instead of sidecar certs.  This secures outside -> in traffic
 	#domain & {
 		domain_key:   defaults.edge.key
 		_force_https: defaults.edge.enable_tls
+		_trust_file: "/etc/proxy/tls/edge/ca.crt"
+		_certificate_path: "/etc/proxy/tls/edge/server.crt"
+		_key_path: "/etc/proxy/tls/edge/server.key"
 	},
 	#listener & {
 		listener_key:                defaults.edge.key
@@ -29,10 +33,15 @@ edge_config: [
 	},
 	// This cluster must exist (though it never receives traffic)
 	// so that Catalog will be able to look-up edge instances
-	#cluster & {cluster_key: defaults.edge.key},
+	#cluster & {
+		cluster_key: defaults.edge.key
+	},
 
 	// egress -> redis
-	#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
+	#domain & {
+		domain_key: EgressToRedisName
+		port: defaults.ports.redis_ingress
+	},
 	#cluster & {
 		cluster_key:  EgressToRedisName
 		name:         defaults.redis_cluster_name

--- a/gm/outputs/jwtsecurity.cue
+++ b/gm/outputs/jwtsecurity.cue
@@ -3,13 +3,15 @@
 package greymatter
 
 let Name = "jwt-security"
-let JWTsecurityIngressName = "\(Name)_local"
+let JWTsecurityIngressName = "\(Name)_ingress"
 let EgressToRedisName = "\(Name)_egress_to_redis"
 
 jwtsecurity_config: [
 
 	// jwtsecurity HTTP ingress
-	#domain & {domain_key: JWTsecurityIngressName},
+	#domain & {
+		domain_key: JWTsecurityIngressName
+	},
 	#listener & {
 		listener_key:          JWTsecurityIngressName
 		_spire_self:           Name
@@ -20,7 +22,10 @@ jwtsecurity_config: [
 	#route & {route_key:     JWTsecurityIngressName},
 
 	// egress -> Metrics redis
-	#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
+	#domain & {
+		domain_key: EgressToRedisName
+		port: defaults.ports.redis_ingress
+	},
 	#cluster & {
 		cluster_key:  EgressToRedisName
 		name:         defaults.redis_cluster_name

--- a/gm/outputs/observables.cue
+++ b/gm/outputs/observables.cue
@@ -2,14 +2,16 @@ package greymatter
 
 // Name needs to match the greymatter.io/cluster value in the Kubernetes deployment
 let Name = "observables"
-let ObservablesAppIngressName = "\(Name)_local"
+let ObservablesAppIngressName = "\(Name)_ingress"
 let EgressToRedisName = "\(Name)_egress_to_redis"
 let EgressToElasticSearchName = "\(Name)_egress_to_elasticsearch"
 
 observables_config: [
 
 	// HTTP ingress
-	#domain & {domain_key: ObservablesAppIngressName},
+	#domain & {
+		domain_key: ObservablesAppIngressName
+	},
 	#listener & {
 		listener_key:          ObservablesAppIngressName
 		_spire_self:           Name
@@ -20,7 +22,9 @@ observables_config: [
 	#route & {route_key:     ObservablesAppIngressName},
 
 	// egress -> redis
-	#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
+	#domain & {
+		domain_key: EgressToRedisName, port: defaults.ports.redis_ingress
+	},
 	#cluster & {
 		cluster_key:  EgressToRedisName
 		name:         defaults.redis_cluster_name
@@ -52,7 +56,7 @@ observables_config: [
 	#cluster & {
 		cluster_key:    EgressToElasticSearchName
 		name:           "elasticsearch"
-		require_tls:    true
+		_force_https:   true
 		_upstream_host: defaults.audits.elasticsearch_host
 		_upstream_port: defaults.audits.elasticsearch_port
 	},

--- a/gm/outputs/prometheus.cue
+++ b/gm/outputs/prometheus.cue
@@ -3,12 +3,14 @@
 package greymatter
 
 let Name = "prometheus"
-let LocalName = "\(Name)_local"
+let LocalName = "\(Name)_ingress"
 let EgressToRedisName = "\(Name)_egress_to_redis"
 
 prometheus_config: [
 	// sidecar -> prometheus
-	#domain & {domain_key: LocalName},
+	#domain & {
+		domain_key: LocalName,
+	},
 	#listener & {
 		listener_key:          LocalName
 		_spire_self:           Name
@@ -42,7 +44,10 @@ prometheus_config: [
 	#route & {route_key: LocalName},
 
 	// egress -> redis
-	#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
+	#domain & {
+		domain_key: EgressToRedisName
+		port: defaults.ports.redis_ingress
+	},
 	#cluster & {
 		cluster_key:  EgressToRedisName
 		name:         defaults.redis_cluster_name

--- a/gm/outputs/redis.cue
+++ b/gm/outputs/redis.cue
@@ -1,11 +1,14 @@
 package greymatter
 
 let Name = defaults.redis_cluster_name
-let RedisIngressName = "\(Name)_local"
+let RedisIngressName = "\(Name)_ingress"
 
 redis_config: [
 	// Redis TCP ingress
-	#domain & {domain_key:   RedisIngressName, port:           defaults.ports.redis_ingress},
+	#domain & { 
+    domain_key: RedisIngressName
+    port: defaults.ports.redis_ingress
+  },
 	#cluster & {cluster_key: RedisIngressName, _upstream_port: 6379},
 	// unused route must exist for the cluster to be registered
 	#route & {route_key: RedisIngressName},

--- a/gm/outputs/sidecar.cue
+++ b/gm/outputs/sidecar.cue
@@ -6,7 +6,7 @@ package greymatter
 #sidecar_config: {
 	Name:              string | *defaults.edge.key // workaround for CUE's behavior with conflicting defaults
 	Port:              int | *8080
-	LocalName:         "\(Name)_local"
+	LocalName:         "\(Name)_ingress"
 	EgressToRedisName: "\(Name)_egress_to_redis"
 
 	objects: [

--- a/inputs.cue
+++ b/inputs.cue
@@ -16,7 +16,7 @@ config: {
 	// deploy and configure Prometheus for historical metrics in the Dashboard
 	enable_historical_metrics: bool | *true @tag(enable_historical_metrics,type=bool)
 	// deploy and configure audit pipeline for observability telemetry
-	enable_audits: bool | *true @tag(enable_audits,type=bool)
+	enable_audits: bool | *false @tag(enable_audits,type=bool)
 	// whether to automatically copy the image pull secret to watched namespaces for sidecar injection
 	auto_copy_image_pull_secret: bool | *true @tag(auto_copy_image_pull_secret, type=bool)
 	// namespace the operator will deploy into
@@ -117,7 +117,13 @@ defaults: {
 
 	edge: {
 		key:        "edge"
-		enable_tls: false
+		// edge.enable_tls toggles internal mtls connections between greymatter core components
+		// by default the internal and external secrets are the same however if you want to
+		// have different certs for the ingress and internal connections (this is the case for prod)
+		// then you will need to add those certs to another secret and specity that
+		// below at defaults.core_internal_tls_certs.cert_secret.
+		enable_tls: true
+		secret_name: "gm-edge-ingress-certs"
 		oidc: {
 			endpoint_host: ""
 			endpoint_port: 0
@@ -158,6 +164,12 @@ defaults: {
 		ca_secret_name: "server-ca"
 		// should we request a host mount for the socket, or normal volume mount? If true, also requests hostPID permission
 		host_mount_socket: true
+	}
+
+	core_internal_tls_certs:{
+		// use npe cert for internal mtls
+		// Name of kubernetes secret to be mounted
+		cert_secret: string | *defaults.edge.secret_name 
 	}
 
 } // defaults

--- a/k8s/intermediates.cue
+++ b/k8s/intermediates.cue
@@ -55,6 +55,12 @@ import (
 			mountPath: defaults.spire.socket_mount_path
 		}]
 	}
+	if defaults.edge.enable_tls {
+		[{
+			name: "internal-tls-certs"
+			mountPath: "/etc/proxy/tls/sidecar/"
+		}]
+	}
 	[...]
 }
 
@@ -63,6 +69,12 @@ import (
 		[{
 			name: "spire-socket"
 			hostPath: {path: defaults.spire.socket_mount_path, type: "DirectoryOrCreate"}
+		}]
+	}
+	if defaults.edge.enable_tls {
+		[{
+			name: "internal-tls-certs"
+			secret: {defaultMode: 420, secretName: defaults.edge.secret_name}
 		}]
 	}
 	[...]

--- a/k8s/outputs/edge.cue
+++ b/k8s/outputs/edge.cue
@@ -32,7 +32,7 @@ edge: [
 								if defaults.edge.enable_tls == true {
 									{
 										name:      "tls-certs"
-										mountPath: "/etc/proxy/tls/sidecar"
+										mountPath: "/etc/proxy/tls/edge"
 									}
 								},
 							]
@@ -46,7 +46,10 @@ edge: [
 							if defaults.edge.enable_tls == true {
 							{
 								name: "tls-certs"
-								secret: {defaultMode: 420, secretName: "gm-edge-ingress-certs"}
+								secret: {
+									defaultMode: 420
+									secretName: defaults.edge.secret_name
+								}
 							}
 						},
 					]


### PR DESCRIPTION
Enable mtls for internal mesh components requires tls to be enabled on the edge node.  See docs PR https://github.com/greymatter-io/gm-docs/pull/125.

The default behavior is to re-use the edge ingress secret's data however you can set up a different cert for external tls and internal mTls.

Fundamentally the logic in the domain and cluster functions in intermediate.cue rely on the naming convention of `_local` which allows the function to determine which mesh objects require ssl blocks.  Using this limits the additional fields required in service.cue calls to the functions. 

[sc-20740]