### PR TITLE
Make existence of jwt_security image optional

### DIFF
--- a/gm/outputs/EXTRACTME.cue
+++ b/gm/outputs/EXTRACTME.cue
@@ -24,14 +24,14 @@ redis_listener: redis_listener_object // special because we need to re-apply it 
 
 prometheus_mesh_configs: [ for x in prometheus_config if config.enable_historical_metrics {x}] + catalog_entries
 
-edge_configs: edge_config
-dashboard_configs: dashboard_config
-catalog_configs: catalog_config
+edge_configs:            edge_config
+dashboard_configs:       dashboard_config
+catalog_configs:         catalog_config
 controlensemble_configs: controlensemble_config
-prometheus_configs: prometheus_config
-redis_configs: redis_config
-observables_configs: observables_config
-jwtsecurity_configs: jwtsecurity_config
+prometheus_configs:      prometheus_config
+redis_configs:           redis_config
+observables_configs:     observables_config
+jwtsecurity_configs:     jwtsecurity_config
 
 // for CLI convenience,
 // e.g. `cue eval -c ./gm/outputs --out text -e mesh_configs_yaml`

--- a/gm/outputs/observables.cue
+++ b/gm/outputs/observables.cue
@@ -122,7 +122,7 @@ observables_config: [
 		mesh_id:                   mesh.metadata.name
 		service_id:                "observables"
 		version:                   "0.0.1"
-		description:               "A standalone dashboard visualizaing data collected from Grey Matter audits."
+		description:               "A standalone dashboard visualizing data collected from Grey Matter audits."
 		api_endpoint:              "/services/observables"
 		business_impact:           "critical"
 		enable_instance_metrics:   true

--- a/inputs.cue
+++ b/inputs.cue
@@ -22,7 +22,7 @@ config: {
 	// namespace the operator will deploy into
 	operator_namespace: string | *"gm-operator" @tag(operator_namespace, type=string)
 
-	cluster_ingress_name:   string | *"cluster" // For OpenShift deployments, this is used to look up the configured ingress domain
+	cluster_ingress_name: string | *"cluster" // For OpenShift deployments, this is used to look up the configured ingress domain
 
 	// currently just controls k8s/outputs/operator.cue for debugging
 	debug: bool | *false @tag(debug,type=bool)
@@ -38,14 +38,13 @@ mesh: meshv1.#Mesh & {
 		install_namespace: string | *"greymatter"
 		watch_namespaces:  [...string] | *["default", "plus", "examples"]
 		images: {
-			proxy:        string | *"quay.io/greymatterio/gm-proxy:1.7.1"
-			catalog:      string | *"quay.io/greymatterio/gm-catalog:3.0.5"
-			dashboard:    string | *"quay.io/greymatterio/gm-dashboard:connections"
-			control:      string | *"quay.io/greymatterio/gm-control:1.7.3"
-			control_api:  string | *"quay.io/greymatterio/gm-control-api:1.7.3"
-			redis:        string | *"redis:latest"
-			prometheus:   string | *"prom/prometheus:v2.36.2"
-			jwt_security: string | *"quay.io/greymatterio/gm-jwt-security:1.3.2-rc.1"
+			proxy:       string | *"quay.io/greymatterio/gm-proxy:1.7.1"
+			catalog:     string | *"quay.io/greymatterio/gm-catalog:3.0.5"
+			dashboard:   string | *"quay.io/greymatterio/gm-dashboard:connections"
+			control:     string | *"quay.io/greymatterio/gm-control:1.7.3"
+			control_api: string | *"quay.io/greymatterio/gm-control-api:1.7.3"
+			redis:       string | *"redis:latest"
+			prometheus:  string | *"prom/prometheus:v2.36.2"
 		}
 	}
 }
@@ -114,13 +113,13 @@ defaults: {
 	}
 
 	edge: {
-		key:        "edge"
+		key: "edge"
 		// edge.enable_tls toggles internal mtls connections between greymatter core components
 		// by default the internal and external secrets are the same however if you want to
 		// have different certs for the ingress and internal connections (this is the case for prod)
 		// then you will need to add those certs to another secret and specity that
 		// below at defaults.core_internal_tls_certs.cert_secret.
-		enable_tls: false
+		enable_tls:  false
 		secret_name: "gm-edge-ingress-certs"
 		oidc: {
 			endpoint_host: ""
@@ -164,10 +163,10 @@ defaults: {
 		host_mount_socket: true
 	}
 
-	core_internal_tls_certs:{
+	core_internal_tls_certs: {
 		// use npe cert for internal mtls
 		// Name of kubernetes secret to be mounted
-		cert_secret: string | *defaults.edge.secret_name 
+		cert_secret: string | *defaults.edge.secret_name
 	}
 
 } // defaults

--- a/k8s/outputs/EXTRACTME.cue
+++ b/k8s/outputs/EXTRACTME.cue
@@ -38,7 +38,8 @@ k8s_manifests: controlensemble +
 	[ for x in openshift_spire if config.openshift && config.spire {x}] +
 	[ for x in openshift_spire if config.openshift && config.spire {x}] +
 	[ for x in observables if config.enable_audits {x}] +
-	[ for x in vector if config.enable_audits {x}]
+	[ for x in vector if config.enable_audits {x}] +
+	[ for x in jwt_security_manifests if _enable_jwtsecurity {x}]
 
 vector_manifests_yaml:      yaml.MarshalStream(vector)
 observables_manifests_yaml: yaml.MarshalStream(observables)

--- a/k8s/outputs/jwtsecurity.cue
+++ b/k8s/outputs/jwtsecurity.cue
@@ -6,6 +6,11 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
+_jwtsecurity_image: string | *"quay.io/greymatterio/gm-jwt-security:1.3.2-rc.1"
+if defaults.jwtsecurity_image != _|_ {
+	_jwtsecurity_image: defaults.jwtsecurity_image
+}
+
 let Name = "jwt-security"
 jwt_security: [
 	appsv1.#Deployment & {
@@ -31,7 +36,7 @@ jwt_security: [
 						#sidecar_container_block & {_Name: Name},
 						{
 							name:  Name
-							image: mesh.spec.images.jwt_security
+							image: _jwtsecurity_image
 							ports: [{
 								name:          "http"
 								containerPort: 8080


### PR DESCRIPTION
[sc-28115]
Follow the pattern with the `jwtsecurity`  top-level toggle but for the image name instead. The goal here is that no one should know that jwtsecurity is a thing if they don't dig for it. 

To test,
1. Evaluate the project as is. It should work.
2. In inputs.cue defaults, add `jwtsecurity: true`. Eval both k8s and gm, confirm that the jwt manifests appear and the jwt configs appear.
3.  add to defaults `jwtsecurity_image: "RANDOMNAME"`. Ensure that the k8s manifests contain the new image name. 
4. Set jwtsecurity to false. Ensure both k8s and gm no longer contain jwt.
