### PR TITLE
add ci configs for release

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,0 +1,40 @@
+steps:
+  - label: ":shipit: Build"
+    key: build
+    commands:
+      - ./scripts/cibuild build
+    agents:
+      container_image: ubuntu-2204-ci
+      queue: default
+
+  - label: "Run Tests"
+    key: test
+    depends_on: build
+    commands:
+      - ./scripts/cibuild test
+    agents:
+      container_image: ubuntu-2204-ci
+      queue: default
+
+  - label: "Parse and upload CHANGELOG"
+    key: "parse-and-upload-changelog"
+    commands:
+      - ./scripts/cibuild changelog
+    agents:
+      container_image: ubuntu-2204-ci
+      queue: default
+
+  - trigger: gm-docs-changelog-update
+    depends_on: "parse-and-upload-changelog"
+    label: "Update greymatter-core CHANGELOG in gm-docs"
+    branches: "main"
+    build:
+      meta_data:
+        # The destination filename in gm-docs /data/changelogs
+        changelog_filename: "greymatter-core.toml"
+    async: true
+
+  - label: "Release"
+    depends_on: test
+    commands:
+      - ./scripts/cibuild release

--- a/.buildkite/scheduled-build.yaml
+++ b/.buildkite/scheduled-build.yaml
@@ -1,0 +1,7 @@
+agents:
+  queue: default
+  container_image: ubuntu-2204-ci
+
+steps:
+  - label: "Scheduled build"
+    command: ./scripts/cibuild build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNEXT
 
+## Added
+
+- Add CI configuration for testing builds and publishing releases
+
 ### Changed
 
 - Prometheus and Redis now pulling from Quay because of Docker Hub rate limiting

--- a/gm/outputs/dashboard.cue
+++ b/gm/outputs/dashboard.cue
@@ -9,8 +9,8 @@ let EgressToRedisName = "\(Name)_egress_to_redis"
 dashboard_config: [
 	// sidecar -> dashboard
 	#domain & {
-    domain_key: LocalName
-  },
+		domain_key: LocalName
+	},
 	#listener & {
 		listener_key:          LocalName
 		_spire_self:           Name
@@ -22,9 +22,9 @@ dashboard_config: [
 
 	// egress -> redis
 	#domain & {
-    domain_key: EgressToRedisName
-    port: defaults.ports.redis_ingress
-  },
+		domain_key: EgressToRedisName
+		port:       defaults.ports.redis_ingress
+	},
 	#cluster & {
 		cluster_key:  EgressToRedisName
 		name:         defaults.redis_cluster_name
@@ -54,6 +54,22 @@ dashboard_config: [
 		cluster_key:  Name
 		_spire_other: Name
 	},
-	#route & {domain_key: defaults.edge.key, route_key: Name},
-
+	#route & {
+		domain_key: defaults.edge.key
+		route_key:  Name
+		// If you want the dashboard to be served from it's own sub-route
+		// in the mesh, you can use the following configuration. You may
+		// change the "path" and "from" values accordingly to meet your
+		// enterprise routing needs.
+		// route_match: {
+		//     path:       "/dashboard/"
+		// }
+		// redirects: [
+		//     {
+		//         from:          "^/dashboard$"
+		//         to:            route_match.path
+		//         redirect_type: "permanent"
+		//     },
+		// ]
+	},
 ]

--- a/inputs.cue
+++ b/inputs.cue
@@ -102,14 +102,15 @@ defaults: {
 		// will generate a new index each month. The index configuration can be changed
 		// to create more or less indexes depending on your storage and performance requirements.
 		index: "gm-audits-%Y-%m"
-		// elasticsearch_host can be an IP address or DNS hostname to your Elasticsearch instace.
+		// elasticsearch_host can be an IP address or DNS hostname to your Elasticsearch instance.
 		elasticsearch_host: ""
 		// elasticsearch_port is the port of your Elasticsearch instance.
 		elasticsearch_port: 443
-		// whether the egress-to-ES cluster should look for manually-mounted certificates in /etc/proxy/tls/sidecar
+		// mounted_certs determines whether the observables application uses certificates
+		// mounted at /etc/proxy/tls/sidecar in the observables application's sidecar. 
 		mounted_certs: bool | *false
 		// elasticsearch_endpoint is the full endpoint containing protocol, host, and port
-		// of your Elasticsearch instance. This is used by Vector to sink audit data
+		// of your Elasticsearch instance. This is used by to sync audit data
 		// with Elasticsearch.
 		elasticsearch_endpoint: "https://\(elasticsearch_host):\(elasticsearch_port)"
 	}

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -4,10 +4,10 @@ set -e
 
 for dependency in git
 do
-    if ! which $dependency &> /dev/null; then
-        echo "$dependency is missing from your \$PATH"
-        exit 1
-    elif [ "$dependency" == "git" ]; then
-        git submodule update --init --recursive --remote
-    fi
+  if ! which $dependency &> /dev/null; then
+    echo "$dependency is missing from your \$PATH"
+    exit 1
+  elif [ "$dependency" == "git" ]; then
+    git submodule update --init --recursive
+  fi
 done

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+set -e
+
+# Tar and push bundle to Artifactory; we expect built artifacts on disk
+release_bundle() {
+  if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
+    bundle_and_push "latest"
+  fi
+  if [[ -n "$BUILDKITE_TAG" ]]; then
+    bundle_and_push ${BUILDKITE_TAG:1}
+  fi
+}
+
+# Convenience function to push tarball to Artifactory
+bundle_and_push() {
+  local tag=$1
+  local workspace="/tmp/greymatter-core"
+  local tarball="greymatter_core_${tag}.tar.gz"
+
+  mkdir -p $workspace
+
+  # Create the tarball and exclude unnecessary files for the release bundle.
+  tar \
+    --exclude-vcs \
+    --exclude=".buildkite" \
+    --exclude="CHANGELOG.md"\
+    --exclude="scripts/cibuild" \
+    --exclude="scripts/bootstrap" \
+    --exclude="scripts/update" \
+    -cvzf "$workspace/$tarball" .
+
+  cd $workspace
+
+  # Nexus upload. We are not using the nexus-upload-archive script because this
+  # tarball does not need to meet OS architecture constraints. It is simply a
+  # tarball of directory contents.
+  curl -u "$NEXUS_USER:$NEXUS_PASS" --upload-file "./$tarball" "https://nexus.greymatter.io/repository/raw/development/greymatter-core/$tarball"
+
+  # Artifactory upload
+  buildkite-agent artifact upload "$tarball" "rt://dev-generic/greymatter-core"
+  
+  # Cleanup the tarball
+  rm $tarball
+}
+
+#### Commands
+
+# Parse CHANGELOG into structured data suitable for powering templates
+# on our documentation site.
+cmd_changelog() {
+  export changelog_toml="/tmp/changelog.toml"
+  parse-changelog CHANGELOG.md $changelog_toml
+  buildkite-agent artifact upload $changelog_toml
+}
+
+# There isn't a build per se. We just need to make sure that we have
+# greymatter-cue submodule on disk.
+cmd_build() {
+  ./scripts/bootstrap
+
+  # always push latest tarball when merging to main
+  if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
+    release_bundle
+  fi
+}
+
+# Install the greymatter-cue and run 'cue eval' tests.
+cmd_test() {
+  ./scripts/bootstrap
+  ./scripts/test eval_all
+}
+
+# Pushes the greymatter-core tarball to Artifactory if merging into main or if a tag
+# was detected.
+cmd_release() {
+  if [[ "$BUILDKITE_BRANCH" != "main" && -z $BUILDKITE_TAG ]]; then
+    echo "Skipping release: Release conditions not detected."
+    return 0
+  fi
+
+  # Most commands will call bootstrap since each step may run on a different
+  # machine, one which may not have the dependancies installed.
+  ./scripts/bootstrap
+
+  release_bundle
+}
+
+if [ $# -eq 0 ]; then
+  echo "missing argument"
+  exit 1
+fi
+
+CMD=$1
+shift
+case $CMD in
+  build|changelog|release|test)
+    cmd_$CMD "$@"
+    ;;
+  *)
+    echo "invalid argument: $CMD"
+    exit 1
+    ;;
+esac

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cmd_eval_all () {
+  cmd_eval_gm
+  cmd_eval_k8s
+  cmd_eval_spire
+}
+
+cmd_eval_gm () {
+  echo "Running cue eval on greymatter configs..."
+  result=$(cue eval -c ./gm/outputs --out json)
+  if echo $result | jq -e 'has("controlensemble_config")' >/dev/null; then
+    echo "Test ${FUNCNAME[0]}............PASSED"
+  fi
+}
+
+cmd_eval_k8s () {
+  echo "Running cue eval on Kubernetes configs..."
+  result=$(cue eval -c ./k8s/outputs --out json)
+  if echo $result | jq -e 'has("operator_manifests")' >/dev/null; then
+    echo "Test ${FUNCNAME[0]}............PASSED"
+  fi
+}
+
+cmd_eval_spire () {
+  echo "Running cue eval on greymatter configs with Spire..."
+
+  result=$(cue eval -t spire=true -c ./gm/outputs --out json)
+  cluster=$(echo $result | jq '.controlensemble_config[] | select(.cluster_key=="controlensemble")')
+  secret_validation_name=$(echo $cluster | jq -r '.secret.secret_validation_name')
+  expected_value="spiffe://greymatter.io"
+
+  if [ "$secret_validation_name" = "$expected_value" ]; then
+    echo "Test ${FUNCNAME[0]}............PASSED"
+  else
+    echo "Test ${FUNCNAME[0]}............FAILED"
+    echo "Did not find {secret_validation_name: \"$expected_value\"} in cluster."
+    echo $cluster | jq
+    exit 1
+  fi
+
+  echo "Running cue eval on Kubernetes configs with Spire..."
+
+  result=$(cue eval -t spire=true -c ./k8s/outputs -e operator_manifests --out json)
+  spire_namespace=$(echo $result | jq '.[] | select(.metadata.name=="spire")')
+
+  if [ ! -z "$spire_namespace" ]; then
+    echo "Test ${FUNCNAME[0]}............PASSED"
+  else
+    echo "Test ${FUNCNAME[0]}............FAILED"
+    echo "Failed to find spire namespace."
+    exit 1
+  fi
+}
+
+cmd_help () {
+  echo "valid commands: eval help
+  
+eval_all:
+  'cue eval' all configs.
+eval_gm:
+  'cue eval' greymatter mesh configs.
+eval_k8s:
+  'cue eval' Kubernetes manifests.
+eval_spire:
+  'cue eval' greymatter and Kubernetes manifests with Spire.
+help:
+  Print this message and exit."
+}
+
+if [ $# -eq 0 ]; then
+  cmd_help
+else
+  MODE="${1:-}"
+  case "$MODE" in
+    help|eval_all|eval_gm|eval_k8s|eval_spire)
+      shift
+      "cmd_$MODE" "$@"
+      ;;
+    *)
+      cmd_help
+      ;;
+  esac
+fi

--- a/scripts/update
+++ b/scripts/update
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+cmd_pin () {
+  git submodule update --recursive
+}
+
+cmd_latest () {
+  git submodule update --recursive --remote
+}
+
+cmd_help () {
+  echo "valid commands: pin, latest, help
+  
+pin:
+  Will get the greymatter-cue submodule via the pinned commit in this repo.
+latest:
+  Will pull down greymatter-cue submodule from the latest commit.
+help:
+  Print this message and exit."
+}
+
+if [ $# -eq 0 ]; then
+  cmd_help
+else
+  MODE="${1:-}"
+  case "$MODE" in
+    help|pin|latest)
+      shift
+      "cmd_$MODE" "$@"
+      ;;
+    *)
+      cmd_help
+      ;;
+  esac
+fi


### PR DESCRIPTION
This is the first of a few PRs today that transition this repo from gitops-core to greymatter-core. The existing greymatter-core repo will be deleted and this repo renamed. Since most of this comes from two already reviewed/approved PRs from greymatter-core, I don't think too much time needs to be spent re-reviewing.

This PR contains the following changes:

- CI configs https://github.com/greymatter-io/greymatter-core/pull/1 (Coleman previously approved)
- Dashboard route CUE guidance https://github.com/greymatter-io/greymatter-core/pull/4 (Kyle previously approved)
- Minor clean up to inputs.cue